### PR TITLE
[templatetags-hotfix] Pull tests out of templatetags

### DIFF
--- a/metadeploy/api/tests/templatetags_api_bootstrap.py
+++ b/metadeploy/api/tests/templatetags_api_bootstrap.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..api_bootstrap import serialize
+from ..templatetags.api_bootstrap import serialize
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
They'll be imported, as part of the templatetags magic, and make things fall down in staging or production environments without test requirements installed.

![frog](http://www.zooborns.com/.a/6a010535647bf3970b022ad38c9ae8200d-800wi)