### PR TITLE
[fix-custom-domain-login] Fix custom-domain login

### DIFF
--- a/metadeploy/multisalesforce/tests/views.py
+++ b/metadeploy/multisalesforce/tests/views.py
@@ -2,5 +2,7 @@ from ..views import SalesforceOAuth2CustomAdapter
 
 
 def test_SalesforceOAuth2CustomAdapter_base_url(rf):
-    adapter = SalesforceOAuth2CustomAdapter(rf.get('/?custom_domain=foo'))
+    request = rf.get('/?custom_domain=foo')
+    request.session = {}
+    adapter = SalesforceOAuth2CustomAdapter(request)
     assert adapter.base_url == 'https://foo.my.salesforce.com'

--- a/metadeploy/multisalesforce/views.py
+++ b/metadeploy/multisalesforce/views.py
@@ -26,9 +26,12 @@ class SalesforceOAuth2CustomAdapter(SalesforceOAuth2BaseAdapter):
 
     @property
     def base_url(self):
-        return 'https://{}.my.salesforce.com'.format(
-            self.request.GET.get("custom_domain"),
+        custom_domain = self.request.GET.get(
+            'custom_domain',
+            self.request.session.get('custom_domain'),
         )
+        self.request.session['custom_domain'] = custom_domain
+        return 'https://{}.my.salesforce.com'.format(custom_domain)
 
 
 prod_oauth2_login = OAuth2LoginView.adapter_view(


### PR DESCRIPTION
Now we store custom domain in the session.

This way it will persist across the OAuth conversation, and can be used in the OAuth callback on the MetaDeploy side to get a token from the Salesforce side.

![tiger](http://www.zooborns.com/.a/6a010535647bf3970b022ad3aeb975200b-800wi)