### PR TITLE
log rq job id when in a job

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -328,6 +328,9 @@ LOGGING = {
     'filters': {
         'request_id': {
             '()': 'log_request_id.filters.RequestIDFilter'
+        },
+        'job_id': {
+            '()': 'metadeploy.logfmt.JobIDFilter'
         }
     },
     'formatters': {
@@ -349,7 +352,7 @@ LOGGING = {
         "rq_console": {
             "level": "DEBUG",
             "class": "rq.utils.ColorizingStreamHandler",
-            'filters': [],
+            'filters': ["job_id"],
             "formatter": "verbose",
         },
     },

--- a/metadeploy/logfmt.py
+++ b/metadeploy/logfmt.py
@@ -1,8 +1,18 @@
-import datetime
 import numbers
+import logging
+import datetime
 
 from django.utils.log import ServerFormatter
+from rq import get_current_job
 
+NO_JOB_ID = 'no-job-id'
+
+class JobIDFilter(logging.Filter):
+    def filter(self, record):
+        if get_current_job():
+            record.job_id = get_current_job().id
+        else:
+            record.job_id = NO_JOB_ID
 
 class LogfmtFormatter(ServerFormatter):
     """
@@ -50,10 +60,10 @@ class LogfmtFormatter(ServerFormatter):
             record,
             'request_id',
             None,
-            # ) or getattr(
-            #     record,
-            #     'msg',  # TODO: Parse the Job ID out of the msg :(
-            #     None,
+            ) or getattr(
+                 record,
+                 'job_id',
+                 None,
         ) or 'unknown'
 
     def _get_tag(self, record):

--- a/metadeploy/logfmt.py
+++ b/metadeploy/logfmt.py
@@ -5,7 +5,9 @@ import datetime
 from django.utils.log import ServerFormatter
 from rq import get_current_job
 
+
 NO_JOB_ID = 'no-job-id'
+
 
 class JobIDFilter(logging.Filter):
     def filter(self, record):
@@ -14,6 +16,7 @@ class JobIDFilter(logging.Filter):
         else:
             record.job_id = NO_JOB_ID
         return True
+
 
 class LogfmtFormatter(ServerFormatter):
     """
@@ -80,7 +83,7 @@ class LogfmtFormatter(ServerFormatter):
         tag = self._get_tag(record)
         rest = self.format_line(getattr(record, 'context', {}))
         return ' '.join(filter(None, [
-            f'id={id_}',  # TODO: get-id method
+            f'id={id_}',
             f'at={record.levelname}',
             f'time={time}',
             f'msg={msg}',

--- a/metadeploy/logfmt.py
+++ b/metadeploy/logfmt.py
@@ -13,6 +13,7 @@ class JobIDFilter(logging.Filter):
             record.job_id = get_current_job().id
         else:
             record.job_id = NO_JOB_ID
+        return True
 
 class LogfmtFormatter(ServerFormatter):
     """
@@ -61,9 +62,9 @@ class LogfmtFormatter(ServerFormatter):
             'request_id',
             None,
             ) or getattr(
-                 record,
-                 'job_id',
-                 None,
+                record,
+                'job_id',
+                None,
         ) or 'unknown'
 
     def _get_tag(self, record):


### PR DESCRIPTION

![cooper in a hoodie](https://user-images.githubusercontent.com/164/46033462-1c395b00-c0b3-11e8-9383-2191d720cd21.png)

Attach a logging filter (ala [using filters to impart contextual information](https://docs.python.org/2/howto/logging-cookbook.html#using-filters-to-impart-contextual-information), the same technique used by django_log_request_id) to the rq_console logging handler. It adds the current job_id to the JobRecord if we're in a job.