### PR TITLE
Add custom RQ worker that closes DB connections

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -338,6 +338,9 @@ RQ_QUEUES = {
         'DEFAULT_TIMEOUT': 10,
     },
 }
+RQ = {
+    'WORKER_CLASS': 'metadeploy.rq_worker.ConnectionClosingWorker',
+}
 
 
 # SF Connected App and GitHub configuration:

--- a/metadeploy/api/jobs.py
+++ b/metadeploy/api/jobs.py
@@ -149,7 +149,7 @@ def enqueuer():
         rq_job = run_flows_job.delay(
             j.user,
             j.plan,
-            j.steps,
+            list(j.steps.all()),
         )
         j.job_id = rq_job.id
         j.enqueued_at = rq_job.enqueued_at

--- a/metadeploy/api/management/commands/populate_sample_products.py
+++ b/metadeploy/api/management/commands/populate_sample_products.py
@@ -1,5 +1,8 @@
 from django.core.management.base import BaseCommand
 from django.utils.text import slugify
+from django.utils import timezone
+
+from scheduler.models import RepeatableJob
 
 from ...models import (
     Product,
@@ -66,7 +69,18 @@ class Command(BaseCommand):
     def create_step(self, **kwargs):
         return Step.objects.create(**kwargs)
 
+    def create_enqueuer_job(self):
+        RepeatableJob.objects.create(
+            callable='metadeploy.api.jobs.enqueuer_job',
+            name='Enqueuer',
+            interval=1,
+            interval_unit='minutes',
+            queue='default',
+            scheduled_time=timezone.now(),
+        )
+
     def handle(self, *args, **options):
+        self.create_enqueuer_job()
         sf_category = ProductCategory.objects.create(title='salesforce')
         co_category = ProductCategory.objects.create(title='community')
         product1 = self.create_product(

--- a/metadeploy/rq_worker.py
+++ b/metadeploy/rq_worker.py
@@ -1,0 +1,26 @@
+from django.db import connections, DatabaseError, InterfaceError
+from rq.worker import Worker
+
+
+class ConnectionClosingWorker(Worker):
+    def close_database(self):
+        for connection in connections.all():
+            try:
+                connection.close()
+            except InterfaceError:
+                pass
+            except DatabaseError as e:
+                str_exc = str(e)
+                if 'closed' not in str_exc and 'not connected' not in str_exc:
+                    raise
+
+    def perform_job(self, *args, **kwargs):
+        self.close_database()
+        try:
+            return super().perform_job(*args, **kwargs)
+        finally:
+            self.close_database()
+
+    def work(self, *args, **kwargs):
+        self.close_database()
+        return super().work(*args, **kwargs)

--- a/metadeploy/tests/rq_worker.py
+++ b/metadeploy/tests/rq_worker.py
@@ -1,0 +1,73 @@
+import pytest
+from unittest.mock import MagicMock
+
+from django.db import DatabaseError, InterfaceError
+
+from django_rq import get_worker
+
+
+class TestConnectionClosingWorker:
+    def test_close_database__good(self, mocker):
+        conn = MagicMock()
+        all_ = mocker.patch('django.db.connections.all')
+        all_.return_value = [conn]
+
+        worker = get_worker()
+        worker.close_database()
+
+        assert conn.close.called
+
+    def test_close_database__interface_error(self, mocker):
+        conn = MagicMock()
+        conn.close.side_effect = InterfaceError()
+        all_ = mocker.patch('django.db.connections.all')
+        all_.return_value = [conn]
+
+        worker = get_worker()
+        worker.close_database()
+
+        assert conn.close.called
+
+    def test_close_database__database_error__reraise(self, mocker):
+        conn = MagicMock()
+        conn.close.side_effect = DatabaseError('reraise me')
+        all_ = mocker.patch('django.db.connections.all')
+        all_.return_value = [conn]
+
+        worker = get_worker()
+        with pytest.raises(DatabaseError):
+            worker.close_database()
+
+    def test_close_database__database_error__no_reraise(self, mocker):
+        conn = MagicMock()
+        conn.close.side_effect = DatabaseError(
+            "closed not connected don't reraise me",
+        )
+        all_ = mocker.patch('django.db.connections.all')
+        all_.return_value = [conn]
+
+        worker = get_worker()
+        worker.close_database()
+
+        assert conn.close.called
+
+    def test_perform_job(self, mocker):
+        close_database = mocker.patch(
+            'metadeploy.rq_worker.ConnectionClosingWorker.close_database',
+        )
+        mocker.patch('rq.worker.Worker.perform_job')
+
+        worker = get_worker()
+        # Symbolic call only, since we've mocked out the super:
+        worker.perform_job(None, None)
+
+        assert close_database.called
+
+    def test_work(self, mocker):
+        close_database = mocker.patch(
+            'metadeploy.rq_worker.ConnectionClosingWorker.close_database',
+        )
+        worker = get_worker()
+        worker.work(burst=True)
+
+        assert close_database.called


### PR DESCRIPTION
The tests are mock-heavy, but I think accurate.

![elephant](http://www.zooborns.com/.a/6a010535647bf3970b022ad395b08f200d-800wi)