### PR TITLE
[add-queue-result-ttl] Add default result TTL to queues

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -332,10 +332,12 @@ RQ_QUEUES = {
     'default': {
         'USE_REDIS_CACHE': 'default',
         'DEFAULT_TIMEOUT': 360,
+        'DEFAULT_RESULT_TTL': 720,
     },
     'short': {
         'USE_REDIS_CACHE': 'default',
         'DEFAULT_TIMEOUT': 10,
+        'DEFAULT_RESULT_TTL': 300,
     },
 }
 RQ = {

--- a/package.json
+++ b/package.json
@@ -89,9 +89,10 @@
   "scripts": {
     "webpack:serve": "webpack-dev-server --config webpack.dev.js",
     "django:serve": "python manage.py runserver",
+    "redis:clear": "redis-cli FLUSHALL",
     "worker:serve": "python manage.py rqworker default short",
     "scheduler:serve": "python manage.py rqscheduler default short",
-    "rq:serve": "run-p worker:serve scheduler:serve",
+    "rq:serve": "npm-run-all redis:clear -p worker:serve scheduler:serve",
     "serve": "run-p django:serve webpack:serve rq:serve",
     "prettier": "prettier --write '*.js' '.*.js' 'src/js/*.js' 'src/js/**/*.js' 'test/js/*.js' 'test/js/**/*.js' 'src/sass/**/*.scss'",
     "eslint": "eslint '*.js' 'src/js/*.js' 'src/js/**/*.js' 'test/js/*.js' 'test/js/**/*.js'",


### PR DESCRIPTION
Maybe also run `redis-cli FLUSHALL` before running the server to clear out old things?