### PR TITLE
use default manager for User

### DIFF
--- a/metadeploy/api/models.py
+++ b/metadeploy/api/models.py
@@ -7,6 +7,7 @@ from asgiref.sync import async_to_sync
 from colorfield.fields import ColorField
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import UserManager as DjangoUserManager
 from django.contrib.postgres.fields import JSONField
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
@@ -48,7 +49,7 @@ class UserQuerySet(models.QuerySet):
 
 
 class User(AbstractUser):
-    objects = UserQuerySet.as_manager()
+    objects = DjangoUserManager.from_queryset(UserQuerySet)()
 
     @property
     def org_name(self):


### PR DESCRIPTION
Things like get_by_natural_key that work on a standard Django user model now work on our user model.