### PR TITLE
[flush-credentials] Exclude users with uninfished jobs from token expiry

### DIFF
--- a/metadeploy/api/models.py
+++ b/metadeploy/api/models.py
@@ -11,7 +11,7 @@ from django.contrib.postgres.fields import JSONField
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import models
-from django.db.models import Count
+from django.db.models import Count, Q
 from django.utils import timezone
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
@@ -44,7 +44,10 @@ class UserQuerySet(models.QuerySet):
         token_lifetime_ago = timezone.now() - timedelta(
             minutes=settings.TOKEN_LIFETIME_MINUTES
         )
-        return self.filter(socialaccount__last_login__lte=token_lifetime_ago)
+        return self.filter(socialaccount__last_login__lte=token_lifetime_ago).exclude(
+            Q(job__status=Job.Status.started)
+            | Q(preflightresult__status=PreflightResult.Status.started)
+        )
 
 
 class User(AbstractUser):

--- a/metadeploy/api/tests/models.py
+++ b/metadeploy/api/tests/models.py
@@ -1,11 +1,15 @@
+from datetime import timedelta
+
 import pytest
+from allauth.socialaccount.models import SocialAccount
 from django.core.exceptions import (
     MultipleObjectsReturned,
     ObjectDoesNotExist,
     ValidationError,
 )
+from django.utils import timezone
 
-from ..models import Version
+from ..models import Job, User, Version
 
 
 @pytest.mark.django_db
@@ -52,6 +56,33 @@ class TestUser:
 
         user.socialaccount_set.first().socialtoken_set.all().delete()
         assert user.valid_token_for is None
+
+
+@pytest.mark.django_db
+class TestUserExpiredTokens:
+    def test_with_completed_job(self, user_factory, job_factory):
+        now = timezone.now()
+        then = now - timedelta(minutes=20)
+        user = user_factory()
+        SocialAccount.objects.filter(id=user.socialaccount_set.first().id).update(
+            last_login=then
+        )
+        job_factory(user=user, status=Job.Status.complete)
+        job_factory(user=user, status=Job.Status.failed)
+        job_factory(user=user, status=Job.Status.canceled)
+
+        assert user in User.objects.with_expired_tokens()
+
+    def test_with_in_progress_job(self, user_factory, job_factory):
+        now = timezone.now()
+        then = now - timedelta(minutes=20)
+        user = user_factory()
+        SocialAccount.objects.filter(id=user.socialaccount_set.first().id).update(
+            last_login=then
+        )
+        job_factory(user=user, status=Job.Status.started)
+
+        assert user not in User.objects.with_expired_tokens()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
See https://trello.com/c/5esBWARK/49-as-an-admin-i-dont-want-credentials-for-my-org-to-persist-longer-than-they-have-to

![pupper](https://static.boredpanda.com/blog/wp-content/uploads/2018/11/BTFpJxMhWmN-png__700.jpg)