### PR TITLE
[repoctx] CumulusCI Context

### DIFF
--- a/metadeploy/api/cci_configs.py
+++ b/metadeploy/api/cci_configs.py
@@ -11,19 +11,18 @@ def extract_user_and_repo(gh_url):
 
 
 class MetadeployProjectConfig(BaseProjectConfig):
-    def __init__(
-        self, *args, repo_root=None, plan=None, result=None, **kwargs
-    ):  # pragma: nocover
+    def __init__(self, *args, repo_root=None, plan=None, **kwargs):  # pragma: nocover
 
         self.plan = plan
-        self.result = result
-        user, repo_name = extract_user_and_repo(plan.version.product.repo_url)
+        repo_url = plan.version.product.repo_url
+        user, repo_name = extract_user_and_repo(repo_url)
 
         repo_info = {
             "root": repo_root,
-            "url": plan.version.product.repo_url,
+            "url": repo_url,
             "name": repo_name,
             "owner": user,
+            "commit": plan.version.commit_ish,
         }
 
         super().__init__(*args, repo_info=repo_info, **kwargs)

--- a/metadeploy/api/cci_configs.py
+++ b/metadeploy/api/cci_configs.py
@@ -1,4 +1,5 @@
 from cumulusci.core.config import BaseProjectConfig
+from cumulusci.core.runtime import BaseCumulusCI
 
 
 class MetadeployProjectConfig(BaseProjectConfig):
@@ -33,3 +34,7 @@ class MetadeployProjectConfig(BaseProjectConfig):
     @property
     def repo_commit(self):  # pragma: nocover
         return
+
+
+class MetaDeployCCI(BaseCumulusCI):
+    project_config_class = MetadeployProjectConfig

--- a/metadeploy/api/cci_configs.py
+++ b/metadeploy/api/cci_configs.py
@@ -1,39 +1,32 @@
+from urllib.parse import urlparse
+
 from cumulusci.core.config import BaseProjectConfig
 from cumulusci.core.runtime import BaseCumulusCI
 
 
+def extract_user_and_repo(gh_url):
+    path = urlparse(gh_url).path
+    _, user, repo, *_ = path.split("/")
+    return user, repo
+
+
 class MetadeployProjectConfig(BaseProjectConfig):
-    def __init__(self, *args, repo_root=None, **kwargs):  # pragma: nocover
-        self._repo_root = repo_root
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self, *args, repo_root=None, plan=None, result=None, **kwargs
+    ):  # pragma: nocover
 
-    @property
-    def repo_root(self):  # pragma: nocover
-        return self._repo_root
+        self.plan = plan
+        self.result = result
+        user, repo_name = extract_user_and_repo(plan.version.product.repo_url)
 
-    @property
-    def config_project_local_path(self):  # pragma: nocover
-        return
+        repo_info = {
+            "root": repo_root,
+            "url": plan.version.product.repo_url,
+            "name": repo_name,
+            "owner": user,
+        }
 
-    @property
-    def repo_name(self):  # pragma: nocover
-        return
-
-    @property
-    def repo_url(self):  # pragma: nocover
-        return
-
-    @property
-    def repo_owner(self):  # pragma: nocover
-        return
-
-    @property
-    def repo_branch(self):  # pragma: nocover
-        return
-
-    @property
-    def repo_commit(self):  # pragma: nocover
-        return
+        super().__init__(*args, repo_info=repo_info, **kwargs)
 
 
 class MetaDeployCCI(BaseCumulusCI):

--- a/metadeploy/api/jobs.py
+++ b/metadeploy/api/jobs.py
@@ -190,7 +190,7 @@ def run_flows(
             current_org,
         )
 
-        ctx = MetaDeployCCI(repo_root=tmpdirname, plan=plan, result=result)
+        ctx = MetaDeployCCI(repo_root=tmpdirname, plan=plan)
 
         ctx.keychain.set_org(org_config)
 

--- a/metadeploy/api/jobs.py
+++ b/metadeploy/api/jobs.py
@@ -20,7 +20,6 @@ import zipfile
 from datetime import timedelta
 from glob import glob
 from itertools import chain
-from urllib.parse import urlparse
 
 import github3
 from asgiref.sync import async_to_sync
@@ -32,7 +31,7 @@ from django.utils import timezone
 from django_rq import job
 from rq.worker import StopRequested
 
-from . import cci_configs
+from .cci_configs import MetaDeployCCI, extract_user_and_repo
 from .flows import JobFlow, PreflightFlow
 from .models import Job, PreflightResult
 from .push import report_error
@@ -40,12 +39,6 @@ from .push import report_error
 logger = logging.getLogger(__name__)
 User = get_user_model()
 sync_report_error = async_to_sync(report_error)
-
-
-def extract_user_and_repo(gh_url):
-    path = urlparse(gh_url).path
-    _, user, repo, *_ = path.split("/")
-    return user, repo
 
 
 @contextlib.contextmanager
@@ -197,7 +190,7 @@ def run_flows(
             current_org,
         )
 
-        ctx = cci_configs.MetaDeployCCI(repo_root=tmpdirname)
+        ctx = MetaDeployCCI(repo_root=tmpdirname, plan=plan, result=result)
 
         ctx.keychain.set_org(org_config)
 

--- a/metadeploy/api/tests/jobs.py
+++ b/metadeploy/api/tests/jobs.py
@@ -103,9 +103,7 @@ def test_malicious_zip_file(
     zip_file.return_value = zip_file_instance
     mocker.patch("metadeploy.api.jobs.OrgConfig")
     mocker.patch("metadeploy.api.jobs.ServiceConfig")
-    mocker.patch("metadeploy.api.jobs.BaseGlobalConfig")
-    mocker.patch("metadeploy.api.jobs.cci_configs")
-    mocker.patch("metadeploy.api.jobs.BaseProjectKeychain")
+    mocker.patch("metadeploy.api.jobs.MetaDeployCCI")
     job_flow = mocker.patch("metadeploy.api.jobs.JobFlow")
 
     user = user_factory()
@@ -153,9 +151,7 @@ def test_preflight(mocker, user_factory, plan_factory):
     mocker.patch("zipfile.ZipFile")
     mocker.patch("metadeploy.api.jobs.OrgConfig")
     mocker.patch("metadeploy.api.jobs.ServiceConfig")
-    mocker.patch("metadeploy.api.jobs.BaseGlobalConfig")
-    mocker.patch("metadeploy.api.jobs.cci_configs")
-    mocker.patch("metadeploy.api.jobs.BaseProjectKeychain")
+    mocker.patch("metadeploy.api.jobs.MetaDeployCCI")
     preflight_flow = mocker.patch("metadeploy.api.jobs.PreflightFlow")
 
     user = user_factory()


### PR DESCRIPTION
![jasper](https://user-images.githubusercontent.com/164/50307076-371a3200-044c-11e9-8f5b-fcf951b7e293.jpg)

This PR fixes the issue we were seeing in production by making sure that everything needed for repo_info is populated before we construct the project config. It additionally switches us to using the "runtime"/"context" object 

There's some...separation of concerns concerns, and it's all around repo-ish details and how they get passed between the two objects. I think that things are slightly easier to mock, now, but still could be adjusted.