### PR TITLE
📦 switch to a middleware for ip ranges

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -131,6 +131,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "metadeploy.logging_middleware.LoggingMiddleware",
+    "metadeploy.admin_middleware.AdminRestrictMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/metadeploy/admin_middleware.py
+++ b/metadeploy/admin_middleware.py
@@ -1,0 +1,28 @@
+from ipaddress import IPv4Address
+
+from django.conf import settings
+from django.core.exceptions import SuspiciousOperation
+from ipware import get_client_ip
+
+
+class AdminRestrictMiddleware:
+    """
+    A middleware that restricts all access to the admin prefix to allowed IPs.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.ip_ranges = settings.ADMIN_API_ALLOWED_SUBNETS
+
+    def __call__(self, request):
+        if request.path.startswith(f"/{settings.ADMIN_AREA_PREFIX}"):
+            self._validate_ip(request)
+
+        return self.get_response(request)
+
+    def _validate_ip(self, request):
+        ip_str, _ = get_client_ip(request)
+        ip_addr = IPv4Address(ip_str)
+
+        if not any(ip_addr in subnet for subnet in self.ip_ranges):
+            raise SuspiciousOperation(f"Disallowed IP address: {ip_addr}")

--- a/metadeploy/adminapi/api.py
+++ b/metadeploy/adminapi/api.py
@@ -1,38 +1,10 @@
-from ipaddress import IPv4Address, IPv4Network
-from typing import List, Type
-
 from django.apps import apps
-from django.conf import settings
-from django.core import exceptions
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from rest_framework import pagination, permissions, serializers, viewsets
 from rest_framework.response import Response
 
 from metadeploy.api import models
-
-
-class IsAllowedIPAddress(permissions.BasePermission):
-    """Permission check for allowed IP networks.
-    """
-
-    ip_ranges: List[IPv4Network]
-
-    def has_permission(self, request, view):
-        ip_addr = IPv4Address(request.META["REMOTE_ADDR"])
-        if not any(ip_addr in subnet for subnet in self.ip_ranges):
-            raise exceptions.SuspiciousOperation(f"Disallowed IP address: {ip_addr}")
-        return True
-
-
-def AllowedIPRange(
-    ip_ranges: List[IPv4Network], cls_prefix: str = ""
-) -> Type[permissions.BasePermission]:
-    """Factory that returns an IsAllowedIpAddress permission for a list of ip_ranges.
-    """
-    return type(
-        f"{cls_prefix}AllowedIPRange", (IsAllowedIPAddress,), {"ip_ranges": ip_ranges}
-    )
 
 
 class IsAPIUser(permissions.BasePermission):
@@ -112,10 +84,7 @@ class AdminAPIViewSet(viewsets.ModelViewSet):
     serializer_class = None
     route_ns = "admin_rest"
 
-    permission_classes = [
-        AllowedIPRange(settings.ADMIN_API_ALLOWED_SUBNETS, cls_prefix="VPN"),
-        IsAPIUser,
-    ]
+    permission_classes = [IsAPIUser]
 
     # Pagination
     pagination_class = AdminAPIPagination

--- a/metadeploy/logging_middleware.py
+++ b/metadeploy/logging_middleware.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 from django.conf import settings
+from ipware import get_client_ip
 from log_request_id import (
     LOG_REQUESTS_SETTING,
     REQUEST_ID_RESPONSE_HEADER_SETTING,
@@ -39,13 +40,16 @@ class LoggingMiddleware(RequestIDMiddleware):
 
         user = getattr(request, "user", None)
         user_id = getattr(user, "pk", None) or getattr(user, "id", None)
+        ip_str, _ = get_client_ip(request)
+        if not ip_str:
+            ip_str = "unknown"
 
         message = "method=%s path=%s status=%s source_ip=%s user_agent=%s time=%s"
         args = (
             request.method,
             request.path,
             response.status_code,
-            request.META.get("REMOTE_ADDR", "unknown"),
+            ip_str,
             repr(request.META.get("HTTP_USER_AGENT", "unknown")),
             time.time() - local.start_time,
         )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,7 @@ django-js-reverse==0.8.2
 djangorestframework==3.9.1
 django-colorfield==0.1.15
 django-filter==2.1.0
+django-ipware==2.1.0
 django-redis==4.10.0
 django-log-request-id==1.3.2
 raven==6.10.0


### PR DESCRIPTION
validated manually locally. I'd like to make sure the `django-ipware` defaults work on Heroku. it's a very lightweight dependency (with no deps of its own) that has well reasoned logic for detecting the client IP. 

got rid of the scary permissions factory method. all admin prefixed routes get protected by this instead of different mechanisms protecting api vs admin interface.

we should definitely backport this to the template.

![img_0207](https://user-images.githubusercontent.com/164/51775285-16c43f80-20aa-11e9-82b9-c41fc42a9561.jpeg)
