### PR TITLE
Fix S3 uploads by avoiding setting per-object permissions

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -257,7 +257,7 @@ AWS_SECRET_ACCESS_KEY = env(
 AWS_STORAGE_BUCKET_NAME = env(
     "BUCKETEER_BUCKET_NAME", default=env("AWS_BUCKET_NAME", default=None)
 )
-
+AWS_DEFAULT_ACL = None
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/


### PR DESCRIPTION
This tells django-storages to let the S3 objects inherit permissions from the bucket rather than setting per-object permissions (which our AWS user doesn't have permission to do)