### PR TITLE
fix AllowedListOrg serializer to stringify users

### DIFF
--- a/metadeploy/adminapi/api.py
+++ b/metadeploy/adminapi/api.py
@@ -94,5 +94,10 @@ class AllowedListViewSet(AdminAPIViewSet):
     model_name = "AllowedList"
 
 
+class AllowedListOrgSerializer(AdminAPISerializer):
+    created_by = serializers.StringRelatedField()
+
+
 class AllowedListOrgViewSet(AdminAPIViewSet):
     model_name = "AllowedListOrg"
+    serializer_base = AllowedListOrgSerializer

--- a/metadeploy/adminapi/tests/api.py
+++ b/metadeploy/adminapi/tests/api.py
@@ -218,3 +218,14 @@ class TestPlanViewSet:
         response = client.get(f"http://testserver/admin/rest/plans/{plan.id}")
 
         assert response.status_code == 400
+
+
+@pytest.mark.django_db
+class TestAllowedListOrgViewSet:
+    def test_get(self, admin_api_client, allowed_list_org_factory):
+        allowed_list_org_factory()
+
+        url = "http://testserver/admin/rest/allowedlistorgs"
+        response = admin_api_client.get(url)
+        assert response.status_code == 200
+        assert len(response.json()["data"]) == 1

--- a/metadeploy/conftest.py
+++ b/metadeploy/conftest.py
@@ -87,8 +87,10 @@ class AllowedListOrgFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = AllowedListOrg
 
+    allowed_list = factory.SubFactory(AllowedListFactory)
     org_id = factory.fuzzy.FuzzyText(length=15, prefix="00D")
     description = factory.Sequence("Allowed List Org {}".format)
+    created_by = factory.SubFactory(UserFactory)
 
 
 @register


### PR DESCRIPTION
Without this we were getting a 500 because we haven't set up an API route for users.