### PR TITLE
Revert "[fix-sfdo-python-dep] 📦 Make sfdo-template-helpers not editable"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,8 @@ jobs:
             yarn
             python3 -m venv venv
             . venv/bin/activate
+            # @@@ temp fix
+            rm -rf ./venv/src/sfdo-template-helpers
             pip install -r requirements/local.txt
       - run:
           name: Check that yarn.lock matches package.json

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,6 +28,6 @@ bleach==3.1.0
 django-hashid-field==2.1.6
 redis==2.10.6  # pyup: <3.0
 logfmt==0.4
-git+https://github.com/SFDO-Tooling/sfdo-template-helpers.git@v0.6.0#egg=sfdo-template-helpers
+-e git+https://github.com/SFDO-Tooling/sfdo-template-helpers.git@v0.6.0#egg=sfdo-template-helpers
 django-parler==1.9.2
 Pillow==6.0.0


### PR DESCRIPTION
Reverts SFDO-Tooling/MetaDeploy#297

> The heroku buildpack uses an old version of pip that doesn't know how to install pep 517-style packages

https://github.com/heroku/heroku-buildpack-python/issues/796