### PR TITLE
[post-logs-styles] Simplify styles from install-logs branch

### DIFF
--- a/src/sass/components/_steps.scss
+++ b/src/sass/components/_steps.scss
@@ -4,7 +4,7 @@
 // Variables used in step table only to help with controlling width/wrapping
 $step-name-min: 300px;
 $step-type-min: 170px;
-$step-badge-min: 100px;
+$step-badge-min: 120px;
 $step-install-min: 150px;
 $step-ending-columns-min: $step-type-min + $step-badge-min + $step-install-min;
 
@@ -27,12 +27,12 @@ $step-ending-columns-min: $step-type-min + $step-badge-min + $step-install-min;
   // set up layout
   tr {
     display: grid;
-    grid-template-columns:
-      [step-row-start name-start] minmax($step-name-min, 4fr)
-      [name-end type-start] minmax($step-type-min, 1.5fr)
-      [type-end badge-start] minmax($step-badge-min, 1fr)
-      [badge-end install-start] minmax($step-install-min, 1fr)
-      [install-end step-row-end];
+    grid-template:
+      'name type badge options'
+      'logs logs logs  logs' auto / minmax($step-name-min, 4fr) minmax(
+        $step-type-min,
+        1.5fr
+      ) minmax($step-badge-min, 1fr) minmax($step-install-min, 1fr);
 
     &:focus,
     &:hover {
@@ -95,8 +95,9 @@ $step-ending-columns-min: $step-type-min + $step-badge-min + $step-install-min;
   }
 
   .plan-step-item-name {
-    grid-column: name-start / step-row-end;
-    grid-row: 1 / span 2;
+    // this one spans all columns and rows
+    // for the opened accordion content to extend full width
+    grid-area: 1 / 1 / -1 / -1;
   }
 
   .plan-step-name {
@@ -104,8 +105,7 @@ $step-ending-columns-min: $step-type-min + $step-badge-min + $step-install-min;
   }
 
   .plan-step-type {
-    grid-column: type-start / type-end;
-    grid-row: 1;
+    grid-area: type;
 
     // aligns the type text with other cell text
     > div {
@@ -121,8 +121,7 @@ $step-ending-columns-min: $step-type-min + $step-badge-min + $step-install-min;
   }
 
   .plan-step-badge-container {
-    grid-column: badge-start / badge-end;
-    grid-row: 1;
+    grid-area: badge;
     // decreasing container padding for better vertical alignment
     // badges have more internal padding
     padding-bottom: 0;
@@ -138,8 +137,7 @@ $step-ending-columns-min: $step-type-min + $step-badge-min + $step-install-min;
   }
 
   .plan-step-options {
-    grid-column: install-start / install-end;
-    grid-row: 1;
+    grid-area: options;
 
     // Completed icon is larger than others. Negative indent helps alignment
     .is-completed {


### PR DESCRIPTION
No Trello story, this is in response to:
https://github.com/SFDO-Tooling/MetaDeploy/pull/258#discussion_r281338128

Original Trello story for Install Logs: https://trello.com/c/pnXbwwSW/101-as-an-admin-i-want-to-view-the-logs-while-running-a-preflight-installation

