### PR TITLE
🛢 Better default for list_for_allowed_by_orgs

### DIFF
--- a/metadeploy/api/migrations/0073_allowedlist_list_for_allowed_by_orgs.py
+++ b/metadeploy/api/migrations/0073_allowedlist_list_for_allowed_by_orgs.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
             model_name="allowedlist",
             name="list_for_allowed_by_orgs",
             field=models.BooleanField(
-                default=True,
+                default=False,
                 help_text=(
                     "If a user is allowed only because they have the right Org Type, "
                     "should this be listed for them? If not, they can still find it if "

--- a/metadeploy/api/models.py
+++ b/metadeploy/api/models.py
@@ -72,7 +72,7 @@ class AllowedList(models.Model):
         help_text="All orgs of these types will be automatically allowed.",
     )
     list_for_allowed_by_orgs = models.BooleanField(
-        default=True,
+        default=False,
         help_text=(
             "If a user is allowed only because they have the right Org Type, should "
             "this be listed for them? If not, they can still find it if they happen to "


### PR DESCRIPTION
Make it private by default.

(I'm intentionally modifying the existing migration rather than creating a new one because it hasn't been run on production yet.)