### PR TITLE
Better error handling for expired tokens and dyno restarts

### DIFF
--- a/metadeploy/api/jobs.py
+++ b/metadeploy/api/jobs.py
@@ -45,18 +45,34 @@ sync_report_error = async_to_sync(report_error)
 
 @contextlib.contextmanager
 def finalize_result(result):
-    error_status = result.Status.failed
-    success_status = result.Status.complete
-
     try:
         yield
-        result.status = success_status
+        result.status = result.Status.complete
         result.success_at = timezone.now()
+    except (StopRequested, ShutDownImminentException):
+        # When an RQ worker gets a SIGTERM, it will initiate a warm shutdown,
+        # trying to wrap up existing tasks and then raising a
+        # ShutDownImminentException or StopRequested exception.
+        # So we want to mark any job that's not done by then as canceled
+        # by catching that exception as it propagates back up.
+        result.status = result.Status.canceled
+        result.canceled_at = timezone.now()
+        result.exception = (
+            "The installation job was interrupted. Please retry the installation."
+        )
+        logger.error(
+            f"{result._meta.model_name} {result.id} canceled due to dyno restart."
+        )
+        raise
+    except StopFlowException as e:
+        # User requested cancellation of job
+        result.status = result.Status.canceled
+        result.canceled_at = timezone.now()
+        result.exception = str(e)
+        logger.info(f"{result._meta.model_name} {result.id} canceled.")
     except Exception as e:
-        if not isinstance(
-            e, (StopRequested, ShutDownImminentException, StopFlowException)
-        ):
-            result.status = error_status
+        # Other failures
+        result.status = result.Status.failed
         result.exception = str(e)
         logger.error(f"{result._meta.model_name} {result.id} failed.")
         raise
@@ -83,23 +99,6 @@ def prepend_python_path(path):
         yield
     finally:
         sys.path = prev_path
-
-
-@contextlib.contextmanager
-def mark_canceled(result):
-    """
-    When an RQ worker gets a SIGTERM, it will initiate a warm shutdown, trying to wrap
-    up existing tasks and then raising a ShutDownImminentException or StopRequested
-    exception. So we want to mark any job that's not done by then as canceled
-    by catching that exception as it propagates back up.
-    """
-    try:
-        yield
-    except (StopRequested, ShutDownImminentException, StopFlowException):
-        result.status = result.Status.canceled
-        result.canceled_at = timezone.now()
-        result.save()
-        raise
 
 
 def is_safe_path(path):
@@ -136,7 +135,6 @@ def run_flows(*, user, plan, skip_tasks, organization_url, result_class, result_
 
     with contextlib.ExitStack() as stack:
         stack.enter_context(finalize_result(result))
-        stack.enter_context(mark_canceled(result))
         stack.enter_context(report_errors_to(user))
         tmpdirname = stack.enter_context(temporary_dir())
 

--- a/metadeploy/api/serializers.py
+++ b/metadeploy/api/serializers.py
@@ -446,6 +446,12 @@ class JobSerializer(ErrorWarningCountMixin, serializers.ModelSerializer):
                 )
             )
 
+        user_has_valid_token = all(user.token)
+        if not user_has_valid_token:
+            raise serializers.ValidationError(
+                _(f"The connection to your org has been lost. Please log in again.")
+            )
+
         data["org_name"] = user.org_name
         data["org_type"] = user.org_type
         data["full_org_type"] = user.full_org_type

--- a/metadeploy/api/tests/jobs.py
+++ b/metadeploy/api/tests/jobs.py
@@ -7,11 +7,12 @@ import vcr
 from django.utils import timezone
 from rq.worker import StopRequested
 
+from ..flows import StopFlowException
 from ..jobs import (
     enqueuer,
     expire_preflights,
     expire_user_tokens,
-    mark_canceled,
+    finalize_result,
     preflight,
     run_flows,
 )
@@ -228,7 +229,7 @@ def test_expire_preflights(user_factory, plan_factory, preflight_result_factory)
 
 
 @pytest.mark.django_db
-def test_mark_canceled(job_factory):
+def test_finalize_result_worker_died(job_factory):
     """
     Why do we raise and then catch a StopRequested you might ask? Well, because it's
     what RQ will internally raise on a SIGTERM, so we're essentially faking the "I got a
@@ -238,7 +239,7 @@ def test_mark_canceled(job_factory):
     """
     job = job_factory(org_id="00Dxxxxxxxxxxxxxxx")
     try:
-        with mark_canceled(job):
+        with finalize_result(job):
             raise StopRequested()
     except StopRequested:
         pass
@@ -246,12 +247,25 @@ def test_mark_canceled(job_factory):
 
 
 @pytest.mark.django_db
-def test_mark_canceled_preflight(user_factory, plan_factory, preflight_result_factory):
+def test_finalize_result_canceled_job(job_factory):
+    # User-requested job cancellation.
+    # Unlike cancelation due to the worker restarting,
+    # this kind doesn't propagate the exception.
+    job = job_factory(org_id="00Dxxxxxxxxxxxxxxx")
+    with finalize_result(job):
+        raise StopFlowException()
+    assert job.status == job.Status.canceled
+
+
+@pytest.mark.django_db
+def test_finalize_result_preflight_worker_died(
+    user_factory, plan_factory, preflight_result_factory
+):
     user = user_factory()
     plan = plan_factory()
     preflight = preflight_result_factory(user=user, plan=plan, org_id=user.org_id)
     try:
-        with mark_canceled(preflight):
+        with finalize_result(preflight):
             raise StopRequested()
     except StopRequested:
         pass


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49014/59115344-1751ca00-8917-11e9-907b-d7b56997a66d.png)

Some improvements to error handling:
1. Validate that the user still has a valid token before scheduling a job. (This is https://trello.com/c/imvWSpW8/155-check-for-valid-token-before-scheduling-job; I still don't really understand how the user can get here since the expiration of the token should remove their access to the install button, but there's evidence that it happens.)
2. Provide a more friendly message when a job is canceled due to the worker dyno restarting.
3. Don't mark the rq job as failed if the job is canceled by user request.