### PR TITLE
Optimize expiration of tokens

### DIFF
--- a/metadeploy/api/tests/jobs.py
+++ b/metadeploy/api/tests/jobs.py
@@ -164,6 +164,16 @@ def test_expire_user_tokens(user_factory):
 
 
 @pytest.mark.django_db
+def test_expire_user_tokens_with_started_job(job_factory):
+    job = job_factory(org_id="00Dxxxxxxxxxxxxxxx")
+    job.user.socialaccount_set.update(last_login=timezone.now() - timedelta(minutes=30))
+
+    expire_user_tokens()
+
+    assert job.user.valid_token_for is not None
+
+
+@pytest.mark.django_db
 def test_preflight(mocker, user_factory, plan_factory, preflight_result_factory):
     run_flows = mocker.patch("metadeploy.api.jobs.run_flows")
 

--- a/metadeploy/api/tests/models.py
+++ b/metadeploy/api/tests/models.py
@@ -1,12 +1,11 @@
 from datetime import timedelta
 
 import pytest
-from allauth.socialaccount.models import SocialAccount
 from django.contrib.sites.models import Site
 from django.core.exceptions import MultipleObjectsReturned, ValidationError
 from django.utils import timezone
 
-from ..models import Job, SiteProfile, User, Version
+from ..models import Job, SiteProfile, Version
 
 
 @pytest.mark.django_db
@@ -214,33 +213,6 @@ class TestUser:
 
         user = user_factory(socialaccount_set=[])
         assert user.full_org_type is None
-
-
-@pytest.mark.django_db
-class TestUserExpiredTokens:
-    def test_with_completed_job(self, user_factory, job_factory):
-        now = timezone.now()
-        then = now - timedelta(minutes=20)
-        user = user_factory()
-        SocialAccount.objects.filter(id=user.socialaccount_set.first().id).update(
-            last_login=then
-        )
-        job_factory(user=user, status=Job.Status.complete, org_id=user.org_id)
-        job_factory(user=user, status=Job.Status.failed, org_id=user.org_id)
-        job_factory(user=user, status=Job.Status.canceled, org_id=user.org_id)
-
-        assert user in User.objects.with_expired_tokens()
-
-    def test_with_in_progress_job(self, user_factory, job_factory):
-        now = timezone.now()
-        then = now - timedelta(minutes=20)
-        user = user_factory()
-        SocialAccount.objects.filter(id=user.socialaccount_set.first().id).update(
-            last_login=then
-        )
-        job_factory(user=user, status=Job.Status.started, org_id=user.org_id)
-
-        assert user not in User.objects.with_expired_tokens()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The previous approach was doing a separate query to delete the SocialToken for each user (except users with recent logins or running jobs) and was taking longer and longer as we accumulate users. This changes it so we're primarily querying tokens (which should always be a fairly short list) and then doing separate queries for each token to confirm the user doesn't have running jobs.

I imagine it's possible to do it as a single query but this is probably good enough.