### PR TITLE
Don't pay attention to list_for_allowed_by_orgs for plans

### DIFF
--- a/metadeploy/api/serializers.py
+++ b/metadeploy/api/serializers.py
@@ -149,7 +149,6 @@ class PlanSerializer(CircumspectSerializerMixin, serializers.ModelSerializer):
     preflight_message = serializers.SerializerMethodField()
     not_allowed_instructions = serializers.SerializerMethodField()
     requires_preflight = serializers.SerializerMethodField()
-    is_listed = serializers.SerializerMethodField()
 
     class Meta:
         model = Plan
@@ -181,11 +180,6 @@ class PlanSerializer(CircumspectSerializerMixin, serializers.ModelSerializer):
 
     def get_is_allowed(self, obj):
         return obj.is_visible_to(self.context["request"].user)
-
-    def get_is_listed(self, obj):
-        return obj.is_listed and not obj.is_listed_by_org_only(
-            self.context["request"].user
-        )
 
     def get_not_allowed_instructions(self, obj):
         if not obj.version.product.is_visible_to(self.context["request"].user):


### PR DESCRIPTION
This was preventing plans from being listed on the product detail page if the user's org has access via the allowed list org type

(For example, log into https://install.salesforce.org/products/sal with a scratch org)