### PR TITLE
[hotfix-plan-modals] Close plan modals on Confirm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "eslint-plugin-flowtype-errors": "^4.1.0",
     "eslint-plugin-import": "^2.17.3",
     "eslint-plugin-prettier": "^3.1.0",
-    "eslint-plugin-react": "^7.14.1",
+    "eslint-plugin-react": "^7.14.2",
     "fetch-mock": "^7.3.3",
     "file-loader": "^4.0.0",
     "flow-bin": "^0.101.1",

--- a/src/js/components/plans/clickThroughAgreementModal.js
+++ b/src/js/components/plans/clickThroughAgreementModal.js
@@ -27,6 +27,12 @@ class ClickThroughAgreementModal extends React.Component<Props, State> {
     this.setState({ confirmed: false });
   };
 
+  handleSubmit = () => {
+    const { startJob } = this.props;
+    this.handleClose();
+    startJob();
+  };
+
   handleChange = (
     event: SyntheticInputEvent<HTMLInputElement>,
     { checked }: { checked: boolean },
@@ -35,7 +41,7 @@ class ClickThroughAgreementModal extends React.Component<Props, State> {
   };
 
   render(): React.Node {
-    const { isOpen, text, startJob } = this.props;
+    const { isOpen, text } = this.props;
     const { confirmed } = this.state;
     const footer = [
       <Button
@@ -47,7 +53,7 @@ class ClickThroughAgreementModal extends React.Component<Props, State> {
         key="submit"
         label={i18n.t('Confirm')}
         variant="brand"
-        onClick={startJob}
+        onClick={this.handleSubmit}
         disabled={!confirmed}
       />,
     ];

--- a/src/js/components/plans/preflightWarningModal.js
+++ b/src/js/components/plans/preflightWarningModal.js
@@ -71,6 +71,12 @@ class PreflightWarningModal extends React.Component<Props, State> {
     this.setState({ confirmed: false });
   };
 
+  handleSubmit = () => {
+    const { startJob } = this.props;
+    this.handleClose();
+    startJob();
+  };
+
   handleChange = (
     event: SyntheticInputEvent<HTMLInputElement>,
     { checked }: { checked: boolean },
@@ -79,7 +85,7 @@ class PreflightWarningModal extends React.Component<Props, State> {
   };
 
   render(): React.Node {
-    const { isOpen, startJob, results, steps, selectedSteps } = this.props;
+    const { isOpen, results, steps, selectedSteps } = this.props;
     const { confirmed } = this.state;
     const footer = [
       <Button
@@ -91,7 +97,7 @@ class PreflightWarningModal extends React.Component<Props, State> {
         key="submit"
         label={i18n.t('Confirm')}
         variant="brand"
-        onClick={startJob}
+        onClick={this.handleSubmit}
         disabled={!confirmed}
       />,
     ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4333,10 +4333,10 @@ eslint-plugin-prettier@^3.1.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react@^7.14.1:
-  version "7.14.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.14.1.tgz#0b49bed8c18b5c2819ea4eb4fdda93e236643198"
-  integrity sha512-fQSIHJ3t0tYgctUyPbcjDPgNUTM6jNFguFKi73ctNjq+8KgqSynMMltakn60/VTtvmNSxOtju/j8Yby8mNn3bQ==
+eslint-plugin-react@^7.14.2:
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.14.2.tgz#94c193cc77a899ac0ecbb2766fbef88685b7ecc1"
+  integrity sha512-jZdnKe3ip7FQOdjxks9XPN0pjUKZYq48OggNMd16Sk+8VXx6JOvXmlElxROCgp7tiUsTsze3jd78s/9AFJP2mA==
   dependencies:
     array-includes "^3.0.3"
     doctrine "^2.1.0"
@@ -6230,7 +6230,7 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
-is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
@@ -7781,9 +7781,9 @@ mississippi@^3.0.0:
     through2 "^2.0.0"
 
 mixin-deep@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
-  integrity sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
+  integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
@@ -10472,20 +10472,10 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-set-value@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
-  integrity sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.1"
-    to-object-path "^0.3.0"
-
-set-value@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
-  integrity sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==
+set-value@^2.0.0, set-value@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
+  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
   dependencies:
     extend-shallow "^2.0.1"
     is-extendable "^0.1.1"
@@ -11649,14 +11639,14 @@ unified@^7.0.0:
     x-is-string "^0.1.0"
 
 union-value@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
-  integrity sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
+  integrity sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==
   dependencies:
     arr-union "^3.1.0"
     get-value "^2.0.6"
     is-extendable "^0.1.1"
-    set-value "^0.4.3"
+    set-value "^2.0.1"
 
 uniq@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
![ape](http://www.prospectmagazine.co.uk/wp-content/uploads/2013/03/205_feature_grayling.jpg)

I'm not sure when this regression was introduced, but this PR fixes a bug where after confirming the preflight-with-warnings modal, it stays open and overlaps with the click-through-agreement modal (see https://metadeploy-devstaging.herokuapp.com/products/product-with-useful-data/0.3.1/preflight-with-warnings):

![Screenshot 2019-06-24 17 39 59](https://user-images.githubusercontent.com/552316/60053924-19ea4880-96a7-11e9-8c18-706e759d67b8.png)
