### PR TITLE
📦 [upgrade-py-deps] Remove pyup dep limitations.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ django-model-utils==3.2.0
 django-parler==1.9.2
 django-redis==4.10.0
 django-rq-scheduler==1.1.3
-django-rq==1.2.0  # pyup: <1.3.0
+django-rq==2.1.0
 django-storages==1.7.1
 Django==2.2.3
 djangorestframework==3.9.4
@@ -27,9 +27,9 @@ Pillow==6.0.0
 psycopg2-binary==2.8.3
 pyopenssl==19.0.0
 raven==6.10.0
-redis==2.10.6  # pyup: <3.0
-rq-scheduler==0.8.3  # pyup: ==0.8.3
-rq==0.12  # pyup: <0.13
+redis==3.2.1
+rq-scheduler==0.9
+rq==1.0
 service_identity==18.1.0
 werkzeug==0.15.4
 whitenoise==4.1.2


### PR DESCRIPTION
@wlonk I see on MetaShare we're using the latest versions of these packages. Upgrading seems to work for me locally -- can you confirm whether or not we can safely remove these PyUp restrictions?

![thinking](https://ramblingrector.files.wordpress.com/2012/10/chimpanzee_thinking_poster.jpg)
