### PR TITLE
Fixes for websocket semaphore

### DIFF
--- a/metadeploy/consumer_utils.py
+++ b/metadeploy/consumer_utils.py
@@ -13,9 +13,12 @@ def message_to_hash(message):
 
 
 async def get_set_message_semaphore(channel_layer, message):
+    """Set a semaphore in redis.
+
+    Used to prevent sending the same message twice within 5 seconds."""
     msg_hash = message_to_hash(message)
     async with channel_layer.connection(0) as connection:
-        return await connection.setnx(msg_hash, 1)
+        return await connection.set(msg_hash, 1, nx=True, ex=5)
 
 
 async def clear_message_semaphore(channel_layer, message):

--- a/metadeploy/consumers.py
+++ b/metadeploy/consumers.py
@@ -30,6 +30,7 @@ class PushNotificationConsumer(AsyncJsonWebsocketConsumer):
 
             channel_layer.group_send(group_name, {
                 'type': 'notify',  # This routes it to this handler.
+                'group': group_name,
                 'content': json_message,
             })
         """

--- a/metadeploy/tests/layer_utils.py
+++ b/metadeploy/tests/layer_utils.py
@@ -2,7 +2,7 @@ from channels.layers import InMemoryChannelLayer
 
 
 class MockedConnection:
-    async def setnx(self, *args, **kwargs):
+    async def set(self, *args, **kwargs):
         return True
 
     async def delete(self, *args, **kwargs):

--- a/src/js/store/org/actions.js
+++ b/src/js/store/org/actions.js
@@ -4,7 +4,6 @@ import type { ThunkAction } from 'redux-thunk';
 
 import apiFetch from 'utils/api';
 import type { Org } from 'store/org/reducer';
-import type { PreflightCompleted } from 'store/plans/actions';
 
 type FetchOrgJobsStarted = {
   type: 'FETCH_ORG_JOBS_STARTED',
@@ -24,8 +23,7 @@ export type OrgAction =
   | FetchOrgJobsStarted
   | FetchOrgJobsSucceeded
   | FetchOrgJobsFailed
-  | OrgChanged
-  | PreflightCompleted;
+  | OrgChanged;
 
 export const fetchOrgJobs = (): ThunkAction => dispatch => {
   dispatch({ type: 'FETCH_ORG_JOBS_STARTED' });

--- a/src/js/store/org/reducer.js
+++ b/src/js/store/org/reducer.js
@@ -23,9 +23,6 @@ const reducer = (org: Org = null, action: OrgAction | LogoutAction): Org => {
     case 'FETCH_ORG_JOBS_SUCCEEDED':
     case 'ORG_CHANGED':
       return action.payload;
-    case 'PREFLIGHT_COMPLETED':
-      // workaround for ORG_CHANGED sometimes being missed
-      return { ...org, current_preflight: null };
   }
   return org;
 };

--- a/test/js/store/org/reducer.test.js
+++ b/test/js/store/org/reducer.test.js
@@ -32,13 +32,4 @@ describe('reducer', () => {
       });
     },
   );
-
-  test('handles PREFLIGHT_COMPLETED action', () => {
-    const initial = { current_preflight: 1 };
-    const expected = { current_preflight: null };
-    const actual = reducer(initial, {
-      type: 'PREFLIGHT_COMPLETED',
-    });
-    expect(actual).toEqual(expected);
-  });
 });


### PR DESCRIPTION
* Include group name in the message so a semaphore for one model doesn't prevent delivery of the same message about a different model
* Expire redis key after 5 seconds so it doesn't prevent future messages if this one goes unreceived
* Remove the workaround I was using to make sure the frontend found out preflight was complete even if the ORG_CHANGED message was not delivered