### PR TITLE
The non-build jobs belong in the short queue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,6 @@
 web: daphne --bind 0.0.0.0 --port $PORT metadeploy.asgi:application
 devworker: python manage.py rqworker default short
-scheduler: python manage.py rqscheduler default short
+scheduler: python manage.py rqscheduler --queue short
 worker: python manage.py rqworker default
 worker-short: python manage.py rqworker short
 release: python manage.py migrate --noinput

--- a/metadeploy/api/management/commands/populate_data.py
+++ b/metadeploy/api/management/commands/populate_data.py
@@ -243,7 +243,7 @@ class Command(BaseCommand):
                 name="Enqueuer",
                 interval=1,
                 interval_unit="minutes",
-                queue="default",
+                queue="short",
                 scheduled_time=timezone.now(),
             ),
         )
@@ -255,7 +255,7 @@ class Command(BaseCommand):
                 name="Expire User Tokens",
                 interval=1,
                 interval_unit="minutes",
-                queue="default",
+                queue="short",
                 scheduled_time=timezone.now(),
             ),
         )
@@ -267,7 +267,7 @@ class Command(BaseCommand):
                 name="Expire Preflight Results",
                 interval=1,
                 interval_unit="minutes",
-                queue="default",
+                queue="short",
                 scheduled_time=timezone.now(),
             ),
         )

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "django:serve": "python manage.py runserver",
     "redis:clear": "redis-cli FLUSHALL",
     "worker:serve": "python manage.py rqworker default short",
-    "scheduler:serve": "python manage.py rqscheduler default short",
+    "scheduler:serve": "python manage.py rqscheduler --queue short",
     "rq:serve": "npm-run-all redis:clear -p worker:serve scheduler:serve",
     "serve": "run-p django:serve webpack:serve rq:serve",
     "prettier": "prettier --write '*.js' '.*.js' 'src/js/*.js' 'src/js/**/*.js' 'test/js/*.js' 'test/js/**/*.js' 'src/sass/**/*.scss'",


### PR DESCRIPTION
This tells the rqscheduler to put repeatable jobs in the "short" queue instead of the default queue.

The scheduler seems to ignore the queue name that is configured on the RepeatableJob records. And the way we were passing queue names to rqscheduler before was also ignored.

I confirmed that jobs enqueued using the delay method (such as the actual preflight and flow runs) still end up in the default queue.

This does mean that it's not possible to set up a RepeatableJob that will use the default queue, which is annoying, but not actually a problem for this project.