### PR TITLE
Fix step ordering function to handle slashes

### DIFF
--- a/metadeploy/api/management/commands/populate_data.py
+++ b/metadeploy/api/management/commands/populate_data.py
@@ -146,7 +146,7 @@ class Command(BaseCommand):
             ),
             is_recommended=False,
             path="quick_task",
-            step_num="0.9",
+            step_num="0/9",
         )
         self.create_step(
             plan=plan,
@@ -327,7 +327,7 @@ class Command(BaseCommand):
                 "description": "",
                 "kind": Step.Kind.metadata,
                 "path": "dependencies.deploy_pre.acc_record_types",
-                "step_num": "1.2.1",
+                "step_num": "1/2/1",
                 "task_class": "cumulusci.tasks.salesforce.UpdateDependencies",
                 "task_config": {
                     "options": {
@@ -347,7 +347,7 @@ class Command(BaseCommand):
                 "description": "",
                 "kind": Step.Kind.metadata,
                 "path": "dependencies.deploy_pre.contact_key_affl_fields",
-                "step_num": "1.2.2",
+                "step_num": "1/2/2",
                 "task_class": "cumulusci.tasks.salesforce.UpdateDependencies",
                 "task_config": {
                     "options": {
@@ -385,7 +385,7 @@ class Command(BaseCommand):
                 "description": "",
                 "kind": Step.Kind.metadata,
                 "path": "deploy_post.course_connection_record_types",
-                "step_num": "3.1",
+                "step_num": "3/1",
                 "task_class": "cumulusci.tasks.salesforce.UpdateDependencies",
                 "task_config": {
                     "options": {
@@ -411,7 +411,7 @@ class Command(BaseCommand):
                 "description": "",
                 "kind": Step.Kind.metadata,
                 "path": "deploy_post.facility_display_name",
-                "step_num": "3.2",
+                "step_num": "3/2",
                 "task_class": "cumulusci.tasks.salesforce.UpdateDependencies",
                 "task_config": {
                     "options": {

--- a/metadeploy/api/tests/models.py
+++ b/metadeploy/api/tests/models.py
@@ -5,7 +5,7 @@ from django.contrib.sites.models import Site
 from django.core.exceptions import MultipleObjectsReturned, ValidationError
 from django.utils import timezone
 
-from ..models import Job, SiteProfile, Version
+from ..models import Job, SiteProfile, Step, Version
 
 
 @pytest.mark.django_db
@@ -435,9 +435,22 @@ class TestPlan:
 
 
 @pytest.mark.django_db
-def test_step_str(step_factory):
-    step = step_factory(name="Test step", step_num="3.1", plan__title="The Plan")
-    assert str(step) == "Step Test step of The Plan (3.1)"
+class TestStep:
+    def test_str(self, step_factory):
+        step = step_factory(name="Test step", step_num="3.1", plan__title="The Plan")
+        assert str(step) == "Step Test step of The Plan (3.1)"
+
+    def test_ordering(self, step_factory):
+        step_factory(step_num="1/1/1")
+        step_factory(step_num="1/1.1")
+        step_factory(step_num="1/1")
+        step_nums = [step.step_num for step in Step.objects.all()]
+        assert step_nums == ["1/1", "1/1.1", "1/1/1"]
+
+    def test_step_num_validator(self, step_factory):
+        step = step_factory(step_num="a")
+        with pytest.raises(ValidationError):
+            step.full_clean()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
We made a change to step_num to add slash separators so that it can represent multiple levels of nested flows even when one level includes dotted numbering. This updates the function used for ordering steps in postgres to handle that.

I also added a validator to make sure that step_num only contains the expected characters.