### PR TITLE
A couple small fixes

### DIFF
--- a/metadeploy/api/admin.py
+++ b/metadeploy/api/admin.py
@@ -121,7 +121,7 @@ class PlanSlugAdmin(admin.ModelAdmin):
 class PreflightResult(admin.ModelAdmin, PlanMixin):
     autocomplete_fields = ("plan", "user")
     list_filter = ("status", "is_valid", "plan__version__product")
-    list_display = ("user", "status", "is_valid", "plan_title", "product", "version")
+    list_display = ("user", "status", "is_valid", "plan_title", "product", "version", "created_at")
     list_select_related = ("user", "plan", "plan__version", "plan__version__product")
     search_fields = ("user", "plan", "exception")
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ bleach==3.1.0
 boto3==1.9.216
 channels==2.2.0
 channels_redis==2.4.0
-cumulusci==2.5.6
+https://github.com/SFDO-Tooling/CumulusCI/tarball/master
 dj-database-url==0.5.0
 django-allauth==0.39.1
 django-colorfield==0.1.15


### PR DESCRIPTION
- Temporarily switch to CumulusCI master to include SFDO-Tooling/CumulusCI#1190
- Show created_at field in the PreflightResult admin listing