### PR TITLE
Locate steps in the db by step_num instead of path

### DIFF
--- a/metadeploy/api/admin.py
+++ b/metadeploy/api/admin.py
@@ -121,7 +121,15 @@ class PlanSlugAdmin(admin.ModelAdmin):
 class PreflightResult(admin.ModelAdmin, PlanMixin):
     autocomplete_fields = ("plan", "user")
     list_filter = ("status", "is_valid", "plan__version__product")
-    list_display = ("user", "status", "is_valid", "plan_title", "product", "version", "created_at")
+    list_display = (
+        "user",
+        "status",
+        "is_valid",
+        "plan_title",
+        "product",
+        "version",
+        "created_at",
+    )
     list_select_related = ("user", "plan", "plan__version", "plan__version__product")
     search_fields = ("user", "plan", "exception")
 

--- a/metadeploy/api/flows.py
+++ b/metadeploy/api/flows.py
@@ -25,7 +25,7 @@ class BasicFlowCallback(FlowCallback):
         try:
             return str(self.context.plan.steps.filter(**filters).first().id)
         except AttributeError:
-            logger.error(f"Unknown task name {path} for {self.context}")
+            logger.error(f"Unknown task {filters} for {self.context}")
             return None
 
     def pre_task(self, step):

--- a/metadeploy/api/tests/flows.py
+++ b/metadeploy/api/tests/flows.py
@@ -16,7 +16,7 @@ from ..models import Step
 def test_get_step_id(mocker):
     callbacks = BasicFlowCallback(sentinel.result)
     callbacks._steps = Step.objects.none()
-    result = callbacks._get_step_id("anything")
+    result = callbacks._get_step_id(step_num="anything")
 
     assert result is None
 
@@ -39,13 +39,13 @@ class TestJobFlow:
         self, mocker, user_factory, plan_factory, step_factory, job_factory
     ):
         plan = plan_factory()
-        steps = [step_factory(plan=plan, path=f"task_{i}") for i in range(3)]
+        steps = [step_factory(plan=plan, step_num=str(i)) for i in range(3)]
 
         job = job_factory(plan=plan, steps=steps, org_id="00Dxxxxxxxxxxxxxxx")
 
         callbacks = JobFlowCallback(job)
 
-        stepspecs = [MagicMock(path=f"task_{i}") for i in range(3)]
+        stepspecs = [MagicMock(step_num=str(i)) for i in range(3)]
         MagicMock(exception=None)
 
         callbacks.pre_flow(sentinel.flow_coordinator)
@@ -60,7 +60,7 @@ class TestJobFlow:
         self, mocker, user_factory, plan_factory, step_factory, job_factory
     ):
         plan = plan_factory()
-        steps = [step_factory(plan=plan, path=f"task_{i}") for i in range(3)]
+        steps = [step_factory(plan=plan, step_num=str(i)) for i in range(3)]
 
         job = job_factory(plan=plan, steps=steps, org_id="00Dxxxxxxxxxxxxxxx")
 
@@ -68,7 +68,7 @@ class TestJobFlow:
 
         stepspecs = [MagicMock() for _ in range(3)]
         for i, stepspec in enumerate(stepspecs):
-            stepspec.path = f"task_{i}"
+            stepspec.step_num = str(i)
         result = MagicMock(exception=None)
 
         callbacks.pre_flow(sentinel.flow_coordinator)
@@ -83,13 +83,13 @@ class TestJobFlow:
     ):
         user = user_factory()
         plan = plan_factory()
-        steps = [step_factory(plan=plan, path=f"task_{i}") for i in range(3)]
+        steps = [step_factory(plan=plan, step_num=str(i)) for i in range(3)]
 
         job = job_factory(user=user, plan=plan, steps=steps, org_id=user.org_id)
 
         callbacks = JobFlowCallback(job)
 
-        step = MagicMock(path="task_0")
+        step = MagicMock(step_num="0")
         step.result = MagicMock(exception=ValueError("Some error"))
 
         callbacks.pre_flow(sentinel.flow_coordinator)


### PR DESCRIPTION
path is not guaranteed to be unique because there can be multiple invocations of the same task name in one flow.

I'm keeping the lookup by path when processing preflight results because that's what CumulusCI gives us -- we'll want to fix this too but not as quickly since it requires coordination between packages.