### PR TITLE
Update custom domain modal to remove protocol and domain

### DIFF
--- a/src/js/components/header/customDomainModal.js
+++ b/src/js/components/header/customDomainModal.js
@@ -6,7 +6,7 @@ import Input from '@salesforce/design-system-react/components/input';
 import Modal from '@salesforce/design-system-react/components/modal';
 import i18n from 'i18next';
 
-import { addUrlParams } from 'utils/api';
+import { addUrlParams, extractCustomDomain } from 'utils/api';
 import type { UrlParams } from 'utils/api';
 
 type Props = {
@@ -28,7 +28,7 @@ class CustomDomainModal extends React.Component<Props, { url: string }> {
 
   handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const val = this.state.url.trim();
+    const val = extractCustomDomain(this.state.url.trim());
     if (!val) {
       return;
     }
@@ -91,7 +91,11 @@ class CustomDomainModal extends React.Component<Props, { url: string }> {
               data-testid="custom-domain"
             >
               https://
-              {this.state.url.trim() ? this.state.url.trim() : <em>domain</em>}
+              {this.state.url.trim() ? (
+                extractCustomDomain(this.state.url.trim())
+              ) : (
+                <em>domain</em>
+              )}
               .my.salesforce.com
             </div>
           </Input>

--- a/src/js/utils/api.js
+++ b/src/js/utils/api.js
@@ -104,4 +104,10 @@ export const removeUrlParam = (key: string, search?: string): string => {
   return params.toString();
 };
 
+export const extractCustomDomain = (url: string): string => {
+  const protocol = /(http(s?)):\/\//;
+  const domain = /\.my\.salesforce\.com(\/?)/;
+  return url.replace(protocol, '').replace(domain, '');
+};
+
 export default apiFetch;

--- a/test/js/components/header/customDomainModal.test.js
+++ b/test/js/components/header/customDomainModal.test.js
@@ -36,6 +36,12 @@ describe('<CustomDomainModal />', () => {
     fireEvent.change(input, { target: { value: ' foobar' } });
 
     expect(getByTestId('custom-domain')).toHaveTextContent('foobar');
+
+    fireEvent.change(input, {
+      target: { value: 'https://foobar.my.salesforce.com' },
+    });
+
+    expect(getByTestId('custom-domain')).toHaveTextContent('foobar');
   });
 
   test('updates window.location.href on submit', () => {

--- a/test/js/utils/api.test.js
+++ b/test/js/utils/api.test.js
@@ -1,6 +1,11 @@
 import fetchMock from 'fetch-mock';
 
-import apiFetch, { addUrlParams, getUrlParam, removeUrlParam } from 'utils/api';
+import apiFetch, {
+  addUrlParams,
+  getUrlParam,
+  removeUrlParam,
+  extractCustomDomain,
+} from 'utils/api';
 
 const dispatch = jest.fn();
 
@@ -135,6 +140,16 @@ describe('removeUrlParam', () => {
   test('handles missing param', () => {
     const actual = removeUrlParam('foo');
     const expected = window.location.search;
+
+    return expect(actual).toBe(expected);
+  });
+});
+
+describe('extractCustomDomain', () => {
+  test('extracts custom subdomain from url', () => {
+    const input = 'https://foo-bar-01.cs42.my.salesforce.com/';
+    const expected = 'foo-bar-01.cs42';
+    const actual = extractCustomDomain(input);
 
     return expect(actual).toBe(expected);
   });


### PR DESCRIPTION
When testing installers I'd like to be able to paste:

    https://efficiency-app-148.cs78.my.salesforce.com/

into the custom domain modal, but this results in:

    https://https://efficiency-app-148.cs78.my.salesforce.com/.my.salesforce.com

and a `400 Bad Request`. This PR updates `customDomainModal` to
instead remove the protocol and domain to produce the expected output:

    https://efficiency-app-148.cs78.my.salesforce.com