### PR TITLE
Feature/preflight duplicate step names

### DIFF
--- a/metadeploy/api/flows.py
+++ b/metadeploy/api/flows.py
@@ -97,8 +97,8 @@ class PreflightFlowCallback(BasicFlowCallback):
         """
         results = coordinator.preflight_results
         sanitized_results = {}
-        for path, step_results in results.items():
-            step_id = self._get_step_id(path=path) if path else "plan"
+        for step_num, step_results in results.items():
+            step_id = self._get_step_id(step_num=step_num) if step_num else "plan"
             step_result = step_results[0]
             if step_result["message"]:
                 step_result["message"] = bleach.clean(step_result["message"])

--- a/metadeploy/api/tests/flows.py
+++ b/metadeploy/api/tests/flows.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 from unittest.mock import MagicMock, sentinel
 
 import pytest
@@ -111,17 +112,17 @@ class TestPreflightFlow:
     ):
         user = user_factory()
         plan = plan_factory()
-        step1 = step_factory(plan=plan, path="name_1")
-        step_factory(plan=plan, path="name_2")
-        step3 = step_factory(plan=plan, path="name_3")
-        step4 = step_factory(plan=plan, path="name_4")
-        step5 = step_factory(plan=plan, path="name_5")
+        step1 = step_factory(plan=plan, path="name_1", step_num=LooseVersion("1.1"))
+        step_factory(plan=plan, path="name_2", step_num=LooseVersion("1.2"))
+        step3 = step_factory(plan=plan, path="name_3", step_num=LooseVersion("2"))
+        step4 = step_factory(plan=plan, path="name_4", step_num=LooseVersion("3"))
+        step5 = step_factory(plan=plan, path="name_5", step_num=LooseVersion("3.4"))
         pfr = preflight_result_factory(user=user, plan=plan, org_id=user.org_id)
         results = {
-            "name_1": [{"status": "error", "message": "error 1"}],
-            "name_3": [{"status": "warn", "message": "warn 1"}],
-            "name_4": [{"status": "optional", "message": ""}],
-            "name_5": [{"status": "skip", "message": "skip 1"}],
+            "1.1": [{"status": "error", "message": "error 1"}],
+            "2": [{"status": "warn", "message": "warn 1"}],
+            "3": [{"status": "optional", "message": ""}],
+            "3.4": [{"status": "skip", "message": "skip 1"}],
         }
         flow_coordinator = MagicMock(preflight_results=results)
 

--- a/metadeploy/api/tests/flows.py
+++ b/metadeploy/api/tests/flows.py
@@ -1,4 +1,3 @@
-from distutils.version import LooseVersion
 from unittest.mock import MagicMock, sentinel
 
 import pytest
@@ -112,11 +111,11 @@ class TestPreflightFlow:
     ):
         user = user_factory()
         plan = plan_factory()
-        step1 = step_factory(plan=plan, path="name_1", step_num=LooseVersion("1.1"))
-        step_factory(plan=plan, path="name_2", step_num=LooseVersion("1.2"))
-        step3 = step_factory(plan=plan, path="name_3", step_num=LooseVersion("2"))
-        step4 = step_factory(plan=plan, path="name_4", step_num=LooseVersion("3"))
-        step5 = step_factory(plan=plan, path="name_5", step_num=LooseVersion("3.4"))
+        step1 = step_factory(plan=plan, path="name_1", step_num="1.1")
+        step_factory(plan=plan, path="name_2", step_num="1.2")
+        step3 = step_factory(plan=plan, path="name_3", step_num="2")
+        step4 = step_factory(plan=plan, path="name_4", step_num="3")
+        step5 = step_factory(plan=plan, path="name_5", step_num="3.4")
         pfr = preflight_result_factory(user=user, plan=plan, org_id=user.org_id)
         results = {
             "1.1": [{"status": "error", "message": "error 1"}],

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ bleach==3.1.0
 boto3==1.12.2
 channels==2.4.0
 channels-redis==2.4.1
-cumulusci==3.7.0
+https://github.com/SFDO-Tooling/CumulusCI/archive/master.zip
 dj-database-url==0.5.0
 django-allauth==0.41.0
 django-colorfield==0.2.0


### PR DESCRIPTION
Aligning with CumulusCI [PR 1574](https://github.com/SFDO-Tooling/CumulusCI/pull/1574), use `step_num` as the key for preflight check results rather than `path` to avoid issues where there are duplicated paths.