### PR TITLE
Update LANGUAGES to match LANGUAGE_CODE

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -249,7 +249,7 @@ SECURE_HSTS_PRELOAD = env("SECURE_HSTS_PRELOAD", default=False, type_=boolish)
 
 LANGUAGE_CODE = "en-us"
 LANGUAGES = (
-    ("en", "English (US)"),
+    ("en-us", "English (US)"),
     ("de", "German"),
     ("es", "Spanish"),
     ("fr", "French"),


### PR DESCRIPTION
In testing on metadeploy staging I found an error that was caused by new plans getting created with their language code set to "en" rather than "en-us". I think this should help.