### PR TITLE
Default TLS-related settings based on SECURE_SSL_REDIRECT

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -235,11 +235,18 @@ SECURE_PROXY_SSL_HEADER = env(
     type_=(lambda v: tuple(v.split(":", 1)) if (v is not None and ":" in v) else None),
 )
 SECURE_SSL_REDIRECT = env("SECURE_SSL_REDIRECT", default=True, type_=boolish)
-SESSION_COOKIE_SECURE = env("SESSION_COOKIE_SECURE", default=False, type_=boolish)
-CSRF_COOKIE_SECURE = env("CSRF_COOKIE_SECURE", default=False, type_=boolish)
-SECURE_HSTS_SECONDS = env("SECURE_HSTS_SECONDS", default=0, type_=int)
+SESSION_COOKIE_SECURE = env(
+    "SESSION_COOKIE_SECURE", default=SECURE_SSL_REDIRECT, type_=boolish
+)
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+CSRF_COOKIE_SECURE = env(
+    "CSRF_COOKIE_SECURE", default=SECURE_SSL_REDIRECT, type_=boolish
+)
+SECURE_HSTS_SECONDS = env(
+    "SECURE_HSTS_SECONDS", default=3600 if SECURE_SSL_REDIRECT else 0, type_=int
+)
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env(
-    "SECURE_HSTS_INCLUDE_SUBDOMAINS", default=False, type_=boolish
+    "SECURE_HSTS_INCLUDE_SUBDOMAINS", default=True, type_=boolish
 )
 SECURE_HSTS_PRELOAD = env("SECURE_HSTS_PRELOAD", default=False, type_=boolish)
 

--- a/docs/running_docker.rst
+++ b/docs/running_docker.rst
@@ -140,8 +140,7 @@ DJANGO_DEBUG:
     Please set this to true. Production may want to have this disabled.
 
 SECURE_SSL_REDIRECT:
-    This variable is for Security! Better to use DNS for this task, 
-    but you can use redirect. Please set this variable to false.
+    Set to True to force redirecting to https.
 
 ADMIN_API_ALLOWED_SUBNETS:
     This is a value to signify what subnets are allowed access to the admin view.

--- a/env.example
+++ b/env.example
@@ -15,7 +15,7 @@ export DJANGO_HASHID_SALT='something long and random'
 export DJANGO_ALLOWED_HOSTS=localhost
 export DJANGO_DEBUG=True
 
-# Security! Better to use DNS for this task, but you can use redirect
+# Don't force https when running on localhost
 export SECURE_SSL_REDIRECT=False
 
 # Application Settings


### PR DESCRIPTION
Use safer defaults for https-related settings. SECURE_SSL_REDIRECT is the master switch; if it is on then the others should default to being on as well.