### PR TITLE
Update translations in an rq job

### DIFF
--- a/metadeploy/adminapi/api.py
+++ b/metadeploy/adminapi/api.py
@@ -154,5 +154,5 @@ class TranslationViewSet(viewsets.ViewSet):
                 record.text = message["message"]
                 record.save()
 
-        update_all_translations(lang)
+        update_all_translations.delay(lang)
         return Response({})

--- a/metadeploy/adminapi/tests/translations.py
+++ b/metadeploy/adminapi/tests/translations.py
@@ -1,4 +1,8 @@
+from unittest import mock
+
 import pytest
+
+from metadeploy.adminapi.translations import update_all_translations
 
 
 @pytest.mark.django_db
@@ -10,21 +14,28 @@ class TestTranslationViewSet:
         step2 = step_factory(name="Install Example 1.0", plan=plan)
 
         url = "http://testserver/admin/rest"
-        response = admin_api_client.patch(
-            f"{url}/translations/es",
-            {
-                "example:product": {"title": {"message": "Ejemplo"}},
-                "example:steps": {
-                    "Install {product} {version}": {
-                        "message": "Instalar {product} {version}"
+        with mock.patch(
+            "metadeploy.adminapi.api.update_all_translations"
+        ) as update_job:
+            response = admin_api_client.patch(
+                f"{url}/translations/es",
+                {
+                    "example:product": {"title": {"message": "Ejemplo"}},
+                    "example:steps": {
+                        "Install {product} {version}": {
+                            "message": "Instalar {product} {version}"
+                        },
+                        "Foo": {"message": "Fú"},
                     },
-                    "Foo": {"message": "Fú"},
                 },
-            },
-            format="json",
-        )
+                format="json",
+            )
 
         assert response.status_code == 200
+        update_job.delay.assert_called_once()
+
+        # Synchronously run the job that would normally be run as an rq job
+        update_all_translations("es")
 
         product.set_current_language("es")
         assert product.title == "Ejemplo"

--- a/metadeploy/adminapi/translations.py
+++ b/metadeploy/adminapi/translations.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.conf import settings
+from django_rq import job
 from parler.models import TranslatableModel
 
 from metadeploy.api.models import Translation
@@ -8,6 +9,7 @@ from metadeploy.api.models import Translation
 logger = logging.getLogger(__name__)
 
 
+@job
 def update_all_translations(lang):
     """Update all objects' translations from the Translation model"""
     for model in TranslatableModel.__subclasses__():

--- a/metadeploy/api/admin.py
+++ b/metadeploy/api/admin.py
@@ -201,3 +201,4 @@ class SiteProfileAdmin(TranslatableAdmin):
 @admin.register(Translation)
 class TranslationAdmin(admin.ModelAdmin):
     list_display = ("lang", "context", "slug", "text")
+    list_filter = ("lang",)


### PR DESCRIPTION
update_all_translations can take a while; let's run it in an rq job so it doesn't hold up requests.

I also added a language filter to the Admin UI for the Translation model