### PR TITLE
Use step_num instead of path to identify skipped steps

### DIFF
--- a/metadeploy/api/models.py
+++ b/metadeploy/api/models.py
@@ -643,9 +643,9 @@ class Job(HashIdMixin, models.Model):
     def subscribable_by(self, user):
         return self.is_public or user.is_staff or user == self.user
 
-    def skip_tasks(self):
+    def skip_steps(self):
         return [
-            step.path for step in set(self.plan.steps.all()) - set(self.steps.all())
+            step.step_num for step in set(self.plan.steps.all()) - set(self.steps.all())
         ]
 
     def _push_if_condition(self, condition, fn):

--- a/metadeploy/api/tests/jobs.py
+++ b/metadeploy/api/tests/jobs.py
@@ -28,14 +28,14 @@ def test_report_error(mocker, job_factory, user_factory, plan_factory, step_fact
 
     user = user_factory()
     plan = plan_factory()
-    steps = [step_factory(plan=plan)]
+    step_factory(plan=plan)
     job = job_factory(user=user, plan=plan, org_id=user.org_id)
 
     with pytest.raises(Exception):
         run_flows(
             user=user,
             plan=plan,
-            skip_tasks=steps,
+            skip_steps=[],
             organization_url=job.organization_url,
             result_class=Job,
             result_id=job.id,
@@ -53,13 +53,13 @@ def test_run_flows(mocker, job_factory, user_factory, plan_factory, step_factory
 
     user = user_factory()
     plan = plan_factory()
-    steps = [step_factory(plan=plan)]
+    step_factory(plan=plan)
     job = job_factory(user=user, plan=plan, org_id=user.org_id)
 
     run_flows(
         user=user,
         plan=plan,
-        skip_tasks=steps,
+        skip_steps=[],
         organization_url=job.organization_url,
         result_class=Job,
         result_id=job.id,
@@ -77,7 +77,7 @@ def test_run_flows__preflight(
 
     user = user_factory()
     plan = plan_factory()
-    steps = [step_factory(plan=plan)]
+    step_factory(plan=plan)
     preflight_result = preflight_result_factory(
         user=user, plan=plan, org_id=user.org_id
     )
@@ -85,7 +85,7 @@ def test_run_flows__preflight(
     run_flows(
         user=user,
         plan=plan,
-        skip_tasks=steps,
+        skip_steps=[],
         organization_url=preflight_result.organization_url,
         result_class=PreflightResult,
         result_id=preflight_result.id,
@@ -134,13 +134,13 @@ def test_malicious_zip_file(
 
     user = user_factory()
     plan = plan_factory()
-    steps = [step_factory(plan=plan)]
+    step_factory(plan=plan)
     job = job_factory(user=user, org_id=user.org_id)
 
     run_flows(
         user=user,
         plan=plan,
-        skip_tasks=steps,
+        skip_steps=[],
         organization_url=job.organization_url,
         result_class=Job,
         result_id=job.id,

--- a/metadeploy/api/tests/models.py
+++ b/metadeploy/api/tests/models.py
@@ -510,14 +510,14 @@ class TestJob:
 
         assert job.click_through_agreement.text == "Test"
 
-    def test_skip_tasks(self, plan_factory, step_factory, job_factory):
+    def test_skip_steps(self, plan_factory, step_factory, job_factory):
         plan = plan_factory()
         step1 = step_factory(plan=plan, path="task1")
         step2 = step_factory(plan=plan, path="task2")
         step3 = step_factory(plan=plan, path="task3")
         job = job_factory(plan=plan, steps=[step1, step3], org_id="00Dxxxxxxxxxxxxxxx")
 
-        assert job.skip_tasks() == [step2.path]
+        assert job.skip_steps() == [step2.step_num]
 
     def test_invalidate_related_preflight(self, job_factory, preflight_result_factory):
         job = job_factory(org_id="00Dxxxxxxxxxxxxxxx")

--- a/metadeploy/tests/integration.py
+++ b/metadeploy/tests/integration.py
@@ -58,13 +58,13 @@ def test_can_reach_salesforce(
     product = product_factory(repo_url="https://github.com/SFDO-Tooling/CumulusCI-Test")
     version = version_factory(commit_ish="feature/preflight", product=product)
     plan = plan_factory(version=version)
-    steps = [step_factory(plan=plan)]
+    step_factory(plan=plan)
     job = job_factory(user=user)
 
     run_flows(
         user=user,
         plan=plan,
-        skip_tasks=steps,
+        skip_steps=[],
         organization_url=INSTANCE_URL,
         result_class=Job,
         result_id=job.id,


### PR DESCRIPTION
This fixes a bug where the wrong step could be skipped if it shared a step path with another step.