### PR TITLE
Allow use of GitHub App

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -312,7 +312,24 @@ STATIC_ROOT = str(PROJECT_ROOT / "staticfiles")
 CONNECTED_APP_CLIENT_SECRET = env("CONNECTED_APP_CLIENT_SECRET")
 CONNECTED_APP_CALLBACK_URL = env("CONNECTED_APP_CALLBACK_URL")
 CONNECTED_APP_CLIENT_ID = env("CONNECTED_APP_CLIENT_ID")
-GITHUB_TOKEN = env("GITHUB_TOKEN")
+GITHUB_TOKEN = env("GITHUB_TOKEN", default=None)
+if GITHUB_TOKEN in ("", "None"):
+    GITHUB_TOKEN = None
+GITHUB_APP_ID = env("GITHUB_APP_ID", default=None)
+if GITHUB_APP_ID in ("", "None"):
+    GITHUB_APP_ID = None
+GITHUB_APP_KEY = env("GITHUB_APP_KEY", default=None)
+if GITHUB_APP_KEY in ("", "None"):
+    GITHUB_APP_KEY = None
+
+if GITHUB_TOKEN is None and GITHUB_APP_ID is None and GITHUB_APP_KEY is None:
+    raise ImproperlyConfigured(
+        "You must set either GITHUB_TOKEN or GITHUB_APP_ID and GITHUB_APP_KEY"
+    )
+if GITHUB_APP_ID is not None and GITHUB_APP_KEY is None:
+    raise ImproperlyConfigured("You must set GITHUB_APP_KEY if GITHUB_APP_ID is set")
+if GITHUB_APP_ID is None and GITHUB_APP_KEY is not None:
+    raise ImproperlyConfigured("You must set GITHUB_APP_ID if GITHUB_APP_KEY is set")
 
 SOCIALACCOUNT_PROVIDERS = {
     "salesforce": {

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -72,6 +72,8 @@ def env(name, default=NoDefaultValue, type_=str):
     except KeyError:
         if default == NoDefaultValue:
             raise ImproperlyConfigured(f"Missing environment variable: {name}.")
+        elif default is None:
+            return None
         val = default
     val = type_(val)
     return val
@@ -313,22 +315,16 @@ CONNECTED_APP_CLIENT_SECRET = env("CONNECTED_APP_CLIENT_SECRET")
 CONNECTED_APP_CALLBACK_URL = env("CONNECTED_APP_CALLBACK_URL")
 CONNECTED_APP_CLIENT_ID = env("CONNECTED_APP_CLIENT_ID")
 GITHUB_TOKEN = env("GITHUB_TOKEN", default=None)
-if GITHUB_TOKEN in ("", "None"):
-    GITHUB_TOKEN = None
 GITHUB_APP_ID = env("GITHUB_APP_ID", default=None)
-if GITHUB_APP_ID in ("", "None"):
-    GITHUB_APP_ID = None
 GITHUB_APP_KEY = env("GITHUB_APP_KEY", default=None)
-if GITHUB_APP_KEY in ("", "None"):
-    GITHUB_APP_KEY = None
 
-if GITHUB_TOKEN is None and GITHUB_APP_ID is None and GITHUB_APP_KEY is None:
+if not GITHUB_TOKEN and not GITHUB_APP_ID and not GITHUB_APP_KEY:
     raise ImproperlyConfigured(
         "You must set either GITHUB_TOKEN or GITHUB_APP_ID and GITHUB_APP_KEY"
     )
-if GITHUB_APP_ID is not None and GITHUB_APP_KEY is None:
+if GITHUB_APP_ID and not GITHUB_APP_KEY:
     raise ImproperlyConfigured("You must set GITHUB_APP_KEY if GITHUB_APP_ID is set")
-if GITHUB_APP_ID is None and GITHUB_APP_KEY is not None:
+if GITHUB_APP_KEY and not GITHUB_APP_ID:
     raise ImproperlyConfigured("You must set GITHUB_APP_ID if GITHUB_APP_KEY is set")
 
 SOCIALACCOUNT_PROVIDERS = {

--- a/metadeploy/api/tests/jobs.py
+++ b/metadeploy/api/tests/jobs.py
@@ -22,7 +22,7 @@ from ..models import Job, PreflightResult
 
 @pytest.mark.django_db
 def test_report_error(mocker, job_factory, user_factory, plan_factory, step_factory):
-    login = mocker.patch("metadeploy.api.jobs.github3.login")
+    login = mocker.patch("cumulusci.core.github.get_github_api_for_repo")
     login.side_effect = Exception
     report_error = mocker.patch("metadeploy.api.jobs.sync_report_error")
 
@@ -120,7 +120,7 @@ def test_malicious_zip_file(
     mocker.patch("shutil.rmtree")
     glob = mocker.patch("metadeploy.api.jobs.glob")
     glob.return_value = ["test"]
-    mocker.patch("github3.login")
+    mocker.patch("cumulusci.core.github.get_github_api_for_repo")
     zip_info = MagicMock()
     zip_info.filename = "/etc/passwd"
     zip_file_instance = MagicMock()
@@ -195,7 +195,7 @@ def test_preflight_failure(
 ):
     glob = mocker.patch("metadeploy.api.jobs.glob")
     glob.side_effect = Exception
-    mocker.patch("github3.login")
+    mocker.patch("cumulusci.core.github.get_github_api_for_repo")
 
     user = user_factory()
     plan = plan_factory()

--- a/metadeploy/api/tests/jobs.py
+++ b/metadeploy/api/tests/jobs.py
@@ -22,8 +22,7 @@ from ..models import Job, PreflightResult
 
 @pytest.mark.django_db
 def test_report_error(mocker, job_factory, user_factory, plan_factory, step_factory):
-    login = mocker.patch("cumulusci.core.github.get_github_api_for_repo")
-    login.side_effect = Exception
+    mocker.patch("metadeploy.api.jobs.get_github_api_for_repo", side_effect=Exception)
     report_error = mocker.patch("metadeploy.api.jobs.sync_report_error")
 
     user = user_factory()
@@ -120,7 +119,7 @@ def test_malicious_zip_file(
     mocker.patch("shutil.rmtree")
     glob = mocker.patch("metadeploy.api.jobs.glob")
     glob.return_value = ["test"]
-    mocker.patch("cumulusci.core.github.get_github_api_for_repo")
+    mocker.patch("metadeploy.api.jobs.get_github_api_for_repo")
     zip_info = MagicMock()
     zip_info.filename = "/etc/passwd"
     zip_file_instance = MagicMock()
@@ -195,7 +194,7 @@ def test_preflight_failure(
 ):
     glob = mocker.patch("metadeploy.api.jobs.glob")
     glob.side_effect = Exception
-    mocker.patch("cumulusci.core.github.get_github_api_for_repo")
+    mocker.patch("metadeploy.api.jobs.get_github_api_for_repo")
 
     user = user_factory()
     plan = plan_factory()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-cumulusci==3.15.0
+cumulusci==3.16.0.dev1
 
 -e git+https://github.com/SFDO-Tooling/sfdo-template-helpers.git@v0.15.0#egg=sfdo-template-helpers
 Django==2.2.13


### PR DESCRIPTION
Allows for either `GITHUB_TOKEN` to be used with a personal access token or `GITHUB_APP_ID` and `GITHUB_APP_KEY` for using a GitHub App.

- Removed the setting of the github service in the constructed keychain since CumulusCI now will use the `GITHUB_*` environment variables rather than fetching the service from the keychain if the environment variables are set

NOTE: This won't work for any of the github_* tasks in CumulusCI as BaseGithubTask requires that the github service is set in the keychain.  This should be addressed in CumulusCI to have a more intelligent check that checks if the GITHUB_* environment variables are set and falls back to checking the keychain if not.  However, that change isn't required for this PR since MetaDeploy plans typically don't use the github_* tasks from CumulusCI.