### PR TITLE
Capitalize the recommended string for MetaDeploy UI

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -196,7 +196,7 @@
   "productNotAllowed": "Try the <2>list of all products</2>",
   "productNotFound": "We can’t find the product you’re looking for. Try the <2>list of all products</2>?",
   "productWithVersion": "<0>{{product}}</0>, <2>{{version}}</2>",
-  "recommended": "recommended",
+  "recommended": "Recommended",
   "reload the page.": "reload the page.",
   "required": "required",
   "skipped": "skipped",

--- a/locales_dev/en/translation.json
+++ b/locales_dev/en/translation.json
@@ -138,7 +138,7 @@
   "productNotAllowed": "Try the <2>list of all products</2>",
   "productNotFound": "We can’t find the product you’re looking for. Try the <2>list of all products</2>?",
   "productWithVersion": "<0>{{product}}</0> <2>{{version}}</2>",
-  "recommended": "recommended",
+  "recommended": "Recommended",
   "reload the page.": "reload the page.",
   "required": "required",
   "skipped": "skipped",


### PR DESCRIPTION
Capitalize the recommended string for MetaDeploy UI to look nicer in the UI.

Discussed this with @jlantz yesterday. From the code search, it is used only in one file for which I believe it is ok to capitalize. But please check and let me know if we're good to go ahead with this change.

Current screenshot where it is not capital
![Screen Shot 2020-10-14 at 12 36 54 PM](https://user-images.githubusercontent.com/53017695/96186889-f0cf7600-0ef0-11eb-81a4-365f082ef80a.png)
