### PR TITLE
Only use the generic Install {product} {version} label when the default value ends with a number

### DIFF
--- a/metadeploy/adminapi/translations.py
+++ b/metadeploy/adminapi/translations.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from django.conf import settings
 from parler.models import TranslatableModel
@@ -7,6 +8,9 @@ from metadeploy.api.jobs import job
 from metadeploy.api.models import Translation
 
 logger = logging.getLogger(__name__)
+
+
+INSTALL_VERSION_RE = re.compile(r"^Install .*\d$")
 
 
 @job
@@ -37,7 +41,7 @@ def update_translations(obj, langs=None):
             for field in obj._parler_meta.get_translated_fields():
                 slug = getattr(obj, field)
                 product_id = ""
-                if slug.startswith("Install "):
+                if INSTALL_VERSION_RE.match(slug):
                     product_id = slug[8:]
                     slug = "Install {product} {version}"
                 try:


### PR DESCRIPTION
This fixes it so that we use this label in the same cases where the metadeploy_publish task generates it. Before, a label like "Install foo" would be left alone by metadeploy_publish, but MetaDeploy would still convert it to "Install {product} {version}" and look for a translation that doesn't exist.