### PR TITLE
Gracefully handle ip restriction errors when logging in

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -111,7 +111,10 @@ ALLOWED_HOSTS = [
 
 # String of IPs (or ranges) shown to the user if
 # we detect the user has Login IP Ranges in place for their profile
-IPS_TO_ALLOWLIST = env("IPS_TO_ALLOWLIST", default=None)
+IP_RESTRICTED_MESSAGE = env(
+    "IP_RESTRICTED_MESSAGE",
+    default="Unable to access this org because your user has IP Login Ranges that block access.",
+)
 
 
 # Application definition

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -109,8 +109,8 @@ ALLOWED_HOSTS = [
     if el.strip()
 ]
 
-# This is a stringa displayed to the customer if MetaDeploy
-# detects that their org has Login IP Ranges in place for the user
+# String of IPs (or ranges) shown to the user if
+# we detect the user has Login IP Ranges in place for their profile
 IPS_TO_ALLOWLIST = env("IPS_TO_ALLOWLIST", default=None)
 
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -109,9 +109,9 @@ ALLOWED_HOSTS = [
     if el.strip()
 ]
 
-# These are displayed to the customer if MetaDeploy
-# detects that their org has login ip restrictions in place
-IPS_TO_WHITELIST = env("IPS_TO_WHITELIST", default="")
+# This is a stringa displayed to the customer if MetaDeploy
+# detects that their org has Login IP Ranges in place for the user
+IPS_TO_ALLOWLIST = env("IPS_TO_ALLOWLIST", default=None)
 
 
 # Application definition

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -109,6 +109,10 @@ ALLOWED_HOSTS = [
     if el.strip()
 ]
 
+# These are displayed to the customer if MetaDeploy
+# detects that their org has login ip restrictions in place
+IPS_TO_WHITELIST = env("IPS_TO_WHITELIST", default="")
+
 
 # Application definition
 

--- a/metadeploy/tests/views.py
+++ b/metadeploy/tests/views.py
@@ -46,10 +46,10 @@ def test_custom_500_view__ip_restricted_error(render):
         )
     except OAuth2Error:
         allow_list = "0.0.0.1, 0.0.0.2, 0.0.0.3"
-        with mock.patch("metadeploy.views.IPS_TO_ALLOWLIST", allow_list):
+        with mock.patch("metadeploy.views.IP_RESTRICTED_MESSAGE", allow_list):
             factory = RequestFactory()
             request = factory.get("/accounts/salesforce/login/callback/")
             request.user = AnonymousUser()
             custom_500_view(request)
 
-    assert allow_list in render.call_args[1]["context"]["JS_CONTEXT"]["error_message"]
+    assert allow_list == render.call_args[1]["context"]["JS_CONTEXT"]["error_message"]

--- a/metadeploy/tests/views.py
+++ b/metadeploy/tests/views.py
@@ -1,16 +1,18 @@
+import pytest
 from unittest import mock
 
-import pytest
+from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 from django.test import RequestFactory
+from django.contrib.auth.models import AnonymousUser
 from sfdo_template_helpers.oauth2.salesforce.views import SalesforcePermissionsError
 
-from ..views import custom_permission_denied_view
+from ..views import custom_permission_denied_view, custom_500_view
 
 
 @pytest.mark.django_db
 @mock.patch("metadeploy.views.render")
 def test_custom_permission_denied_view__sf_permissions(render):
-    request = RequestFactory()
+    request = RequestFactory().get("path")
     exc = SalesforcePermissionsError("I'm sorry Dave.")
     custom_permission_denied_view(request, exc)
 
@@ -23,11 +25,33 @@ def test_custom_permission_denied_view__sf_permissions(render):
 @pytest.mark.django_db
 @mock.patch("metadeploy.views.render")
 def test_custom_permission_denied_view__unknown_error(render):
-    request = RequestFactory()
+    request = RequestFactory().get("path")
     exc = Exception("I'm sorry Dave.")
     custom_permission_denied_view(request, exc)
 
     assert (
         render.call_args[1]["context"]["JS_CONTEXT"]["error_message"]
         == "An internal error occurred while processing your request."
+    )
+
+
+@pytest.mark.django_db
+@mock.patch("metadeploy.views.render")
+def test_custom_500_view__ip_restricted_error(render):
+    try:
+        # raise this to populate info for
+        # call to sys.exec_info() in the view
+        raise OAuth2Error(
+            'Error retrieving access token: b\'{"error":"invalid_grant","error_description":"ip restricted"}\''
+        )
+    except OAuth2Error:
+        factory = RequestFactory()
+        request = factory.get("/accounts/salesforce/login/callback/")
+        request.user = AnonymousUser()
+        custom_500_view(request)
+
+    expected = render.call_args[1]["context"]["JS_CONTEXT"]["error_message"]
+    assert (
+        "We've detected that your org has ip login recstrictions in place."
+        in render.call_args[1]["context"]["JS_CONTEXT"]["error_message"]
     )

--- a/metadeploy/tests/views.py
+++ b/metadeploy/tests/views.py
@@ -50,7 +50,6 @@ def test_custom_500_view__ip_restricted_error(render):
         request.user = AnonymousUser()
         custom_500_view(request)
 
-    expected = render.call_args[1]["context"]["JS_CONTEXT"]["error_message"]
     assert (
         "We've detected that your org has ip login recstrictions in place."
         in render.call_args[1]["context"]["JS_CONTEXT"]["error_message"]

--- a/metadeploy/tests/views.py
+++ b/metadeploy/tests/views.py
@@ -46,14 +46,11 @@ def test_custom_500_view__ip_restricted_error(render):
             'Error retrieving access token: b\'{"error":"invalid_grant","error_description":"ip restricted"}\''
         )
     except OAuth2Error:
-        test_ips = "0.0.0.1, 0.0.0.2, 0.0.0.3"
-        with mock.patch.dict(os.environ, {"IPS_TO_WHITELIST": test_ips}):
+        allow_list = "0.0.0.1, 0.0.0.2, 0.0.0.3"
+        with mock.patch("metadeploy.views.IPS_TO_ALLOWLIST", allow_list):
             factory = RequestFactory()
             request = factory.get("/accounts/salesforce/login/callback/")
             request.user = AnonymousUser()
             custom_500_view(request)
 
-    assert (
-        IP_RESTRICTED_MSG.format(test_ips)
-        == render.call_args[1]["context"]["JS_CONTEXT"]["error_message"]
-    )
+    assert allow_list in render.call_args[1]["context"]["JS_CONTEXT"]["error_message"]

--- a/metadeploy/tests/views.py
+++ b/metadeploy/tests/views.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from unittest import mock
 
@@ -7,7 +6,7 @@ from django.test import RequestFactory
 from django.contrib.auth.models import AnonymousUser
 from sfdo_template_helpers.oauth2.salesforce.views import SalesforcePermissionsError
 
-from ..views import custom_permission_denied_view, custom_500_view, IP_RESTRICTED_MSG
+from ..views import custom_permission_denied_view, custom_500_view
 
 
 @pytest.mark.django_db

--- a/metadeploy/tests/views.py
+++ b/metadeploy/tests/views.py
@@ -7,7 +7,7 @@ from django.test import RequestFactory
 from django.contrib.auth.models import AnonymousUser
 from sfdo_template_helpers.oauth2.salesforce.views import SalesforcePermissionsError
 
-from ..views import custom_permission_denied_view, custom_500_view
+from ..views import custom_permission_denied_view, custom_500_view, IP_RESTRICTED_MSG
 
 
 @pytest.mark.django_db
@@ -53,4 +53,7 @@ def test_custom_500_view__ip_restricted_error(render):
             request.user = AnonymousUser()
             custom_500_view(request)
 
-    assert test_ips in render.call_args[1]["context"]["JS_CONTEXT"]["error_message"]
+    assert (
+        IP_RESTRICTED_MSG.format(test_ips)
+        == render.call_args[1]["context"]["JS_CONTEXT"]["error_message"]
+    )

--- a/metadeploy/urls.py
+++ b/metadeploy/urls.py
@@ -26,6 +26,7 @@ PREFIX = settings.ADMIN_AREA_PREFIX
 
 # Custom error views
 handler403 = "metadeploy.views.custom_permission_denied_view"
+handler500 = "metadeploy.views.custom_500_view"
 
 
 urlpatterns = [

--- a/metadeploy/views.py
+++ b/metadeploy/views.py
@@ -27,7 +27,7 @@ def custom_permission_denied_view(request, exception):
 
 def custom_500_view(request):
     message = GENERIC_ERROR_MSG
-    error_type, value, traceback = sys.exc_info()
+    value = sys.exc_info()[1]
 
     if "ip restricted" in value.args[0]:
         message = IP_RESTRICTED_MSG

--- a/metadeploy/views.py
+++ b/metadeploy/views.py
@@ -1,7 +1,6 @@
 import sys
 from django.shortcuts import render
 
-from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 from sfdo_template_helpers.oauth2.salesforce.views import SalesforcePermissionsError
 
 from config.settings.base import IPS_TO_ALLOWLIST

--- a/metadeploy/views.py
+++ b/metadeploy/views.py
@@ -4,13 +4,12 @@ from django.shortcuts import render
 from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 from sfdo_template_helpers.oauth2.salesforce.views import SalesforcePermissionsError
 
-from config.settings.base import IPS_TO_WHITELIST
+from config.settings.base import IPS_TO_ALLOWLIST
 
 GENERIC_ERROR_MSG = "An internal error occurred while processing your request."
 
 IP_RESTRICTED_MSG = (
-    "We've detected that your user has login IP ranges in place. "
-    "Please ensure that the following IP addresses are whitelisted in the org you're attempting to login to: {}"
+    "Unable to access this org because your user has IP Login Ranges that block access."
 )
 
 
@@ -32,7 +31,12 @@ def custom_500_view(request):
     error_type, value, traceback = sys.exc_info()
 
     if "ip restricted" in value.args[0]:
-        message = IP_RESTRICTED_MSG.format(IPS_TO_WHITELIST)
+        message = IP_RESTRICTED_MSG
+        if IPS_TO_ALLOWLIST:
+            message += (
+                " Please ensure that the following IP addresses are "
+                f"included in the IP Login Ranges for you user's Profile: {IPS_TO_ALLOWLIST}"
+            )
 
     return render(
         request,

--- a/metadeploy/views.py
+++ b/metadeploy/views.py
@@ -4,6 +4,8 @@ from django.shortcuts import render
 from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 from sfdo_template_helpers.oauth2.salesforce.views import SalesforcePermissionsError
 
+from config.settings.base import IPS_TO_WHITELIST
+
 GENERIC_ERROR_MSG = "An internal error occurred while processing your request."
 
 
@@ -27,7 +29,7 @@ def custom_500_view(request):
     if "ip restricted" in value.args[0]:
         message = (
             "We've detected that your org has ip login recstrictions in place. "
-            "Please whitelist the IP addresses listed in the plan's description."
+            f"Please ensure that the following IP addresses are whitelisted in the org you're attempting to login to: {IPS_TO_WHITELIST}"
         )
 
     return render(

--- a/metadeploy/views.py
+++ b/metadeploy/views.py
@@ -8,6 +8,11 @@ from config.settings.base import IPS_TO_WHITELIST
 
 GENERIC_ERROR_MSG = "An internal error occurred while processing your request."
 
+IP_RESTRICTED_MSG = (
+    "We've detected that your user has login IP ranges in place. "
+    "Please ensure that the following IP addresses are whitelisted in the org you're attempting to login to: {}"
+)
+
 
 def custom_permission_denied_view(request, exception):
     message = GENERIC_ERROR_MSG
@@ -27,10 +32,7 @@ def custom_500_view(request):
     error_type, value, traceback = sys.exc_info()
 
     if "ip restricted" in value.args[0]:
-        message = (
-            "We've detected that your org has ip login recstrictions in place. "
-            f"Please ensure that the following IP addresses are whitelisted in the org you're attempting to login to: {IPS_TO_WHITELIST}"
-        )
+        message = IP_RESTRICTED_MSG.format(IPS_TO_WHITELIST)
 
     return render(
         request,

--- a/metadeploy/views.py
+++ b/metadeploy/views.py
@@ -3,13 +3,9 @@ from django.shortcuts import render
 
 from sfdo_template_helpers.oauth2.salesforce.views import SalesforcePermissionsError
 
-from config.settings.base import IPS_TO_ALLOWLIST
+from config.settings.base import IP_RESTRICTED_MESSAGE
 
 GENERIC_ERROR_MSG = "An internal error occurred while processing your request."
-
-IP_RESTRICTED_MSG = (
-    "Unable to access this org because your user has IP Login Ranges that block access."
-)
 
 
 def custom_permission_denied_view(request, exception):
@@ -30,12 +26,7 @@ def custom_500_view(request):
     value = sys.exc_info()[1]
 
     if "ip restricted" in value.args[0]:
-        message = IP_RESTRICTED_MSG
-        if IPS_TO_ALLOWLIST:
-            message += (
-                " Please ensure that the following IP addresses are "
-                f"included in the IP Login Ranges for you user's Profile: {IPS_TO_ALLOWLIST}"
-            )
+        message = IP_RESTRICTED_MESSAGE
 
     return render(
         request,

--- a/metadeploy/views.py
+++ b/metadeploy/views.py
@@ -1,16 +1,38 @@
+import sys
 from django.shortcuts import render
+
+from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 from sfdo_template_helpers.oauth2.salesforce.views import SalesforcePermissionsError
+
+GENERIC_ERROR_MSG = "An internal error occurred while processing your request."
 
 
 def custom_permission_denied_view(request, exception):
+    message = GENERIC_ERROR_MSG
     if isinstance(exception, SalesforcePermissionsError):
         message = str(exception)
-    else:
-        message = "An internal error occurred while processing your request."
 
     return render(
         request,
         "index.html",
         context={"JS_CONTEXT": {"error_message": message}},
         status=403,
+    )
+
+
+def custom_500_view(request):
+    message = GENERIC_ERROR_MSG
+    error_type, value, traceback = sys.exc_info()
+
+    if "ip restricted" in value.args[0]:
+        message = (
+            "We've detected that your org has ip login recstrictions in place. "
+            "Please whitelist the IP addresses listed in the plan's description."
+        )
+
+    return render(
+        request,
+        "index.html",
+        context={"JS_CONTEXT": {"error_message": message}},
+        status=500,
     )


### PR DESCRIPTION
# Changes
* MetaDeploy now has `custom_500_view` which has default messages for both generic 500 errors as well as when MetaDeploy detects that IP Login Ranges are in place for a user. The message displayed for IP Login Range errors can be overridden by setting the `IP_RESTRICTED_MESSAGE` config variable in Heroku.