### PR TITLE
Add Catalan Spanish to language list.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,3 +24,4 @@ Got feedback?
 
 Please open a new `GitHub Issue
 <https://github.com/SFDO-Tooling/MetaDeploy/issues>`_.
+

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -257,6 +257,7 @@ LANGUAGES = [
     ("en-us", "English (US)"),
     ("ar", "Arabic"),
     ("bg", "Bulgarian"),
+    {"ca-es", "Catalonian Spanish"},
     ("cs", "Czech"),
     ("da", "Danish"),
     ("de", "German"),

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -257,7 +257,7 @@ LANGUAGES = [
     ("en-us", "English (US)"),
     ("ar", "Arabic"),
     ("bg", "Bulgarian"),
-    {"ca-es", "Catalan (Spain)"},
+    {"ca", "Catalan (Spain)"},
     ("cs", "Czech"),
     ("da", "Danish"),
     ("de", "German"),

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -257,7 +257,7 @@ LANGUAGES = [
     ("en-us", "English (US)"),
     ("ar", "Arabic"),
     ("bg", "Bulgarian"),
-    {"ca-es", "Catalonian Spanish"},
+    {"ca-es", "Catalan (Spain)"},
     ("cs", "Czech"),
     ("da", "Danish"),
     ("de", "German"),


### PR DESCRIPTION
Received an error when publishing a product to MetaDeploy `Could not update ca-es translation: 404 Client Error: Not Found for url: https://metadeploy.herokuapp.com/cuteanimals/rest/translations/ca-es`

This will add support for Catalonian Spanish to the list