### PR TITLE
Fix ordering of products

### DIFF
--- a/metadeploy/api/models.py
+++ b/metadeploy/api/models.py
@@ -253,8 +253,10 @@ class ProductSlug(AbstractSlug):
 
 class ProductQuerySet(TranslatableQuerySet):
     def published(self):
-        return self.annotate(version__count=Count("version")).filter(
-            version__count__gte=1
+        return (
+            self.annotate(version__count=Count("version"))
+            .filter(version__count__gte=1)
+            .order_by("order_key")
         )
 
 

--- a/metadeploy/api/tests/serializers.py
+++ b/metadeploy/api/tests/serializers.py
@@ -670,20 +670,22 @@ class TestProductCategorySerializer:
         request = rf.get("")
         request.query_params = {}
         request.user = user_factory()
-        product = product_factory(is_listed=True)
-        version = version_factory(product=product)
-        category = product.category
+        product1 = product_factory(is_listed=True, order_key=1)
+        version1 = version_factory(product=product1)
+        category = product1.category
+        product2 = product_factory(category=category, is_listed=True, order_key=0)
+        version2 = version_factory(product=product2)
         serializer = ProductCategorySerializer(category, context={"request": request})
         results = serializer.data["first_page"].pop("results")
         assert serializer.data["first_page"] == {
-            "count": 1,
+            "count": 2,
             "previous": None,
             "next": None,
         }
         expected = [
             {
-                "id": str(product.id),
-                "title": product.title,
+                "id": str(product2.id),
+                "title": product2.title,
                 "description": "<p>This is a sample product.</p>",
                 "short_description": "",
                 "click_through_agreement": "",
@@ -692,23 +694,51 @@ class TestProductCategorySerializer:
                 "icon": None,
                 "image": None,
                 "most_recent_version": {
-                    "id": str(version.id),
-                    "product": str(product.id),
-                    "label": str(version.label),
+                    "id": str(version2.id),
+                    "product": str(product2.id),
+                    "label": str(version2.label),
                     "description": "A sample version.",
-                    "created_at": format_timestamp(version.created_at),
+                    "created_at": format_timestamp(version2.created_at),
                     "primary_plan": None,
                     "secondary_plan": None,
                     "is_listed": True,
                 },
-                "slug": product.slug,
+                "slug": product2.slug,
                 "old_slugs": [],
                 "is_allowed": True,
                 "is_listed": True,
                 "order_key": 0,
                 "not_allowed_instructions": None,
                 "layout": "Default",
-            }
+            },
+            {
+                "id": str(product1.id),
+                "title": product1.title,
+                "description": "<p>This is a sample product.</p>",
+                "short_description": "",
+                "click_through_agreement": "",
+                "category": "salesforce",
+                "color": "#FFFFFF",
+                "icon": None,
+                "image": None,
+                "most_recent_version": {
+                    "id": str(version1.id),
+                    "product": str(product1.id),
+                    "label": str(version1.label),
+                    "description": "A sample version.",
+                    "created_at": format_timestamp(version1.created_at),
+                    "primary_plan": None,
+                    "secondary_plan": None,
+                    "is_listed": True,
+                },
+                "slug": product1.slug,
+                "old_slugs": [],
+                "is_allowed": True,
+                "is_listed": True,
+                "order_key": 1,
+                "not_allowed_instructions": None,
+                "layout": "Default",
+            },
         ]
         assert results == expected
 


### PR DESCRIPTION
"A model’s Meta.ordering doesn’t affect GROUP BY queries." https://docs.djangoproject.com/en/3.2/releases/3.1/#features-removed-in-3-1