### PR TITLE
make sure metadeploy's connected app is set as the default

### DIFF
--- a/metadeploy/api/jobs.py
+++ b/metadeploy/api/jobs.py
@@ -197,6 +197,7 @@ def run_flows(*, plan, skip_steps, result_class, result_id):
             }
         )
         ctx.keychain.set_service("connected_app", "metadeploy", connected_app)
+        ctx.keychain._default_services["metadeploy"] = "metadeploy"
 
         steps = [
             step.to_spec(


### PR DESCRIPTION
cumulusci 3.38.0 added a built-in connected_app service as the default in the keychain, so adding metadeploy's service is no longer setting it as the implicit default. So let's do that explicitly.