### PR TITLE
Job and preflight completion logging

### DIFF
--- a/metadeploy/api/jobs.py
+++ b/metadeploy/api/jobs.py
@@ -120,9 +120,11 @@ def finalize_result(plan: Plan, result: Union[Job, PreflightResult]):
         raise
     finally:
         duration = (end_time - start_time).seconds
-        if result.is_release_test:
-            job_type = JobType.TEST_JOB
-        elif isinstance(result, PreflightResult):
+        # TBD, dependent on another story.
+        # if result.is_release_test:
+        #    job_type = JobType.TEST_JOB
+        # elif
+        if isinstance(result, PreflightResult):
             job_type = JobType.PREFLIGHT
         elif isinstance(result, Job):
             job_type = JobType.JOB

--- a/metadeploy/api/tests/jobs.py
+++ b/metadeploy/api/tests/jobs.py
@@ -281,7 +281,6 @@ def test_finalize_result_mdapi_error(job_factory, plan_factory, caplog):
 @pytest.mark.django_db
 def test_finalize_result_job_success(job_factory, plan_factory, caplog):
     job = job_factory(org_id="00Dxxxxxxxxxxxxxxx")
-    response = MagicMock(text="text")
     plan = plan_factory()
     with finalize_result(plan, job):
         pass

--- a/metadeploy/api/tests/jobs.py
+++ b/metadeploy/api/tests/jobs.py
@@ -275,7 +275,6 @@ def test_finalize_result_preflight_failed(
     user_factory, plan_factory, preflight_result_factory, caplog
 ):
     user = user_factory()
-    plan = plan_factory()
     preflight = preflight_result_factory(
         user=user,
         plan__version__product__title="Test Product",

--- a/metadeploy/conftest.py
+++ b/metadeploy/conftest.py
@@ -248,6 +248,7 @@ class ScratchOrgFactory(factory.django.DjangoModelFactory):
 class PreflightResultFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = PreflightResult
+
     plan = factory.SubFactory(PlanFactory)
 
 

--- a/metadeploy/conftest.py
+++ b/metadeploy/conftest.py
@@ -248,6 +248,7 @@ class ScratchOrgFactory(factory.django.DjangoModelFactory):
 class PreflightResultFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = PreflightResult
+    plan = factory.SubFactory(PlanFactory)
 
 
 @pytest.fixture


### PR DESCRIPTION
Log when jobs and preflight checks complete with various statuses for ingestion into metrics.

Partially dependent on W-9935537 (for new fields).