### PR TITLE
Adjustments to job logging

### DIFF
--- a/metadeploy/api/jobs.py
+++ b/metadeploy/api/jobs.py
@@ -278,7 +278,7 @@ run_flows_job = job(run_flows)
 
 
 def enqueuer():
-    logger.debug("Enqueuer live", extra={"tag": "jobs.enqueuer"})
+    logger.debug("Enqueuer live")
     for j in Job.objects.filter(enqueued_at=None):
         j.invalidate_related_preflight()
         rq_job = run_flows_job.delay(

--- a/metadeploy/api/jobs.py
+++ b/metadeploy/api/jobs.py
@@ -70,6 +70,7 @@ def finalize_result(result: Union[Job, PreflightResult]):
     start_time = timezone.now()
     end_time = None
     log_status = None
+    log_msg = None
 
     try:
         yield
@@ -82,8 +83,10 @@ def finalize_result(result: Union[Job, PreflightResult]):
             # Determine if the preflight returned a negative status (FAILURE)
             # as opposed to throwing an exception (ERROR)
             log_status = JobLogStatus.FAILURE
+            log_msg = f"{result.__class__.__name__} {result.id} failed"
         else:
             log_status = JobLogStatus.SUCCESS
+            log_msg = f"{result.__class__.__name__} {result.id} succeeded"
     except (StopRequested, ShutDownImminentException):
         # When an RQ worker gets a SIGTERM, it will initiate a warm shutdown,
         # trying to wrap up existing tasks and then raising a
@@ -94,11 +97,9 @@ def finalize_result(result: Union[Job, PreflightResult]):
         result.canceled_at = timezone.now()
         end_time = result.canceled_at
         log_status = JobLogStatus.TERMINATED
+        log_msg = f"{result.__class__.__name__} {result.id} interrupted by dyno restart"
         result.exception = (
             "The installation job was interrupted. Please retry the installation."
-        )
-        logger.error(
-            f"{result._meta.model_name} {result.id} canceled due to dyno restart."
         )
         raise
     except StopFlowException as e:
@@ -107,17 +108,17 @@ def finalize_result(result: Union[Job, PreflightResult]):
         result.canceled_at = timezone.now()
         end_time = result.canceled_at
         log_status = JobLogStatus.CANCELED
+        log_msg = f"{result.__class__.__name__} {result.id} canceled"
         result.exception = str(e)
-        logger.info(f"{result._meta.model_name} {result.id} canceled.")
     except Exception as e:
         # Other failures
         result.status = result.Status.failed
         end_time = timezone.now()
         log_status = JobLogStatus.ERROR
+        log_msg = f"{result.__class__.__name__} {result.id} errored"
         result.exception = str(e)
         if hasattr(e, "response"):
             result.exception += "\n" + e.response.text
-        logger.error(f"{result._meta.model_name} {result.id} failed.")
         raise
     finally:
         duration = (end_time - start_time).seconds
@@ -132,7 +133,7 @@ def finalize_result(result: Union[Job, PreflightResult]):
 
         context = f"{result.plan.version.product.title} {result.plan.version.label}"
         logger.info(
-            "Job reached a completion status",
+            log_msg,
             extra={
                 "context": {
                     "event": f"{job_type}",

--- a/metadeploy/logfmt.py
+++ b/metadeploy/logfmt.py
@@ -82,16 +82,10 @@ class LogfmtFormatter(ServerFormatter):
             or "unknown"
         )
 
-    def _get_tag(self, record):
-        tag = getattr(record, "tag", None)
-        if tag:
-            return quote_logvalue(tag)
-
     def format(self, record):
         parsed_msg = record.module == "logging_middleware"
         id_ = self._get_id(record)
         time = self._get_time(record)
-        tag = self._get_tag(record)
         if parsed_msg:
             msg = self._parse_msg(record.getMessage())
         else:
@@ -107,8 +101,6 @@ class LogfmtFormatter(ServerFormatter):
             f"time={time}",
             f"module={record.module}",
         ]
-        if tag:
-            fields.append(f"tag={tag}")
         if parsed_msg:
             for k, v in msg.items():
                 fields.append(f"{k}={quote_logvalue(str(v))}")

--- a/metadeploy/logfmt.py
+++ b/metadeploy/logfmt.py
@@ -19,6 +19,18 @@ class JobIDFilter(logging.Filter):
         return True
 
 
+def quote_logvalue(value):
+    """Return a value formatted for use in a logfmt log entry.
+
+    The input is quoted if it contains spaces or quotes; otherwise returned unchanged
+    """
+    s = str(value)
+    if " " in s or '"' in s:
+        string = s.replace('"', "\\" + '"')
+        return f'"{s}"'
+    return s
+
+
 class LogfmtFormatter(ServerFormatter):
     """
     To use this logger to its fullest extent, log lines like this:
@@ -38,12 +50,11 @@ class LogfmtFormatter(ServerFormatter):
         msg = list(parse(io.StringIO(msg)))
         return msg[0]
 
-    def _escape_quotes(self, string):
-        return '"{}"'.format(string.replace('"', "\\" + '"'))
-
     def format_line(self, extra):
         out = []
         for k, v in extra.items():
+            if k == "event":
+                continue  # already emitted at the beginning of the line
             if v is None:
                 v = ""
             elif isinstance(v, bool):
@@ -53,12 +64,12 @@ class LogfmtFormatter(ServerFormatter):
             else:
                 if isinstance(v, (dict, object)):
                     v = str(v)
-                v = self._escape_quotes(v)
+                v = quote_logvalue(v)
             out.append("{}={}".format(k, v))
         return " ".join(out)
 
     def _get_time(self, record):
-        return self._escape_quotes(
+        return quote_logvalue(
             datetime.datetime.fromtimestamp(record.created).strftime(
                 "%Y-%m-%d %H:%M:%S.%f"
             )
@@ -74,8 +85,7 @@ class LogfmtFormatter(ServerFormatter):
     def _get_tag(self, record):
         tag = getattr(record, "tag", None)
         if tag:
-            return self._escape_quotes(tag)
-        return "external"
+            return quote_logvalue(tag)
 
     def format(self, record):
         parsed_msg = record.module == "logging_middleware"
@@ -85,19 +95,24 @@ class LogfmtFormatter(ServerFormatter):
         if parsed_msg:
             msg = self._parse_msg(record.getMessage())
         else:
-            msg = self._escape_quotes(record.getMessage())
-        rest = self.format_line(getattr(record, "context", {}))
-        fields = [
+            msg = record.getMessage()
+        context = getattr(record, "context", {})
+        rest = self.format_line(context)
+        fields = []
+        if "event" in context:
+            fields.append(f"event={context['event']}")
+        fields += [
             f"request_id={id_}",
             f"at={record.levelname}",
             f"time={time}",
-            f"tag={tag}",
             f"module={record.module}",
         ]
+        if tag:
+            fields.append(f"tag={tag}")
         if parsed_msg:
             for k, v in msg.items():
-                fields.append(f"{k}={v}")
+                fields.append(f"{k}={quote_logvalue(str(v))}")
         else:
-            fields.append(f"msg={msg}")
+            fields.append(f"msg={quote_logvalue(msg)}")
         fields.append(f"{rest}")
         return " ".join(filter(None, fields))

--- a/metadeploy/logfmt.py
+++ b/metadeploy/logfmt.py
@@ -26,7 +26,7 @@ def quote_logvalue(value):
     """
     s = str(value)
     if " " in s or '"' in s:
-        string = s.replace('"', "\\" + '"')
+        s = s.replace('"', "\\" + '"')
         return f'"{s}"'
     return s
 

--- a/metadeploy/logfmt.py
+++ b/metadeploy/logfmt.py
@@ -100,7 +100,7 @@ class LogfmtFormatter(ServerFormatter):
         rest = self.format_line(context)
         fields = []
         if "event" in context:
-            fields.append(f"event={context['event']}")
+            fields.append(f"event={quote_logvalue(context['event'])}")
         fields += [
             f"request_id={id_}",
             f"at={record.levelname}",

--- a/metadeploy/logging_middleware.py
+++ b/metadeploy/logging_middleware.py
@@ -8,6 +8,7 @@ from log_request_id import (
     local,
 )
 from log_request_id.middleware import RequestIDMiddleware
+from .logfmt import quote_logvalue
 from sfdo_template_helpers.addresses import get_remote_ip
 
 logger = logging.getLogger(__name__)
@@ -52,7 +53,7 @@ class LoggingMiddleware(RequestIDMiddleware):
             request.path,
             response.status_code,
             ip_str,
-            repr(request.META.get("HTTP_USER_AGENT", "unknown")),
+            request.META.get("HTTP_USER_AGENT", "unknown"),
             time.time() - local.start_time,
             x_forwarded_for,
         )
@@ -60,6 +61,8 @@ class LoggingMiddleware(RequestIDMiddleware):
         if user_id:
             message += " user=%s"
             args += (user_id,)
+
+        args = [quote_logvalue(v) for v in args]
 
         logger.info(message, *args)
 

--- a/metadeploy/tests/logfmt.py
+++ b/metadeploy/tests/logfmt.py
@@ -55,7 +55,6 @@ def test_formatter_format():
             "request_id=unknown",
             "at=INFO",
             f'time="{time}"',
-            "tag=external",
             "module=module",
             'msg="Some message"',
         ]
@@ -67,7 +66,7 @@ def test_formatter_format():
 def test_formatter_format_line():
     extra = {"none": None, "bool": True, "number": 1, "dict": {}}
     result = LogfmtFormatter().format_line(extra)
-    expected = 'none= bool=true number=1 dict="{}"'
+    expected = "none= bool=true number=1 dict={}"
 
     assert result == expected
 
@@ -80,7 +79,7 @@ def test_formatter_tag():
     record.tag = "some-tag"
 
     result = LogfmtFormatter()._get_tag(record)
-    expected = '"some-tag"'
+    expected = "some-tag"
 
     assert result == expected
 
@@ -99,7 +98,6 @@ def test_parsed_msg():
             "request_id=unknown",
             "at=INFO",
             f'time="{time}"',
-            "tag=external",
             "module=logging_middleware",
             "foo=bar",
             "baz=qux",

--- a/metadeploy/tests/logfmt.py
+++ b/metadeploy/tests/logfmt.py
@@ -71,19 +71,6 @@ def test_formatter_format_line():
     assert result == expected
 
 
-def test_formatter_tag():
-    record = logging.LogRecord(
-        "name", logging.INFO, "module", 1, "Some message", (), None
-    )
-
-    record.tag = "some-tag"
-
-    result = LogfmtFormatter()._get_tag(record)
-    expected = "some-tag"
-
-    assert result == expected
-
-
 def test_parsed_msg():
     record = logging.LogRecord(
         "name", logging.INFO, "logging_middleware", 1, "foo=bar baz=qux", (), None


### PR DESCRIPTION
- Make sure the event field is emitted at the beginning of the log line (needed in order to be turned into a metric by our log drain app)
- Provide a more human-friendly msg field
- Fixed a number of issues with quoting of logfmt field values
- Removed tag field, which we weren't using