### PR TITLE
Make sure unhandled exceptions in preflight tasks get logged

### DIFF
--- a/metadeploy/api/flows.py
+++ b/metadeploy/api/flows.py
@@ -134,13 +134,12 @@ class PreflightFlowCallback(BasicFlowCallback):
         self.context.save()
 
     def post_task(self, step, result):
-        """Report exception evaluating a preflight task."""
+        """Report exception evaluating a preflight task.
+
+        If there was an exception while running the task,
+        it is stored on the StepResult but we need to re-raise it
+        so that it can be picked up and recorded
+        by the finalize_result context manager
+        """
         if result.exception:
-            error_result = {
-                "plan": {
-                    "status": ERROR,
-                    "message": bleach.clean(str(result.exception)),
-                }
-            }
-            self.context.results.update(error_result)
-            self.context.save()
+            raise result.exception

--- a/metadeploy/api/jobs.py
+++ b/metadeploy/api/jobs.py
@@ -116,7 +116,8 @@ def finalize_result(result: Union[Job, PreflightResult]):
         end_time = timezone.now()
         log_status = JobLogStatus.ERROR
         log_msg = f"{result.__class__.__name__} {result.id} errored"
-        result.exception = str(e)
+        result.exception = "".join(traceback.format_tb(e.__traceback__))
+        result.exception += "\n" + f"{e.__class__.__name__}: {e}"
         if hasattr(e, "response"):
             result.exception += "\n" + e.response.text
         raise

--- a/metadeploy/api/tests/flows.py
+++ b/metadeploy/api/tests/flows.py
@@ -205,6 +205,5 @@ class TestPreflightFlow:
 
         step = MagicMock()
         step.result = MagicMock(exception=ValueError("A value error."))
-        callbacks.post_task(step, step.result)
-
-        assert pfr.results == {"plan": {"status": "error", "message": "A value error."}}
+        with pytest.raises(ValueError, match="A value error."):
+            callbacks.post_task(step, step.result)

--- a/metadeploy/api/tests/jobs.py
+++ b/metadeploy/api/tests/jobs.py
@@ -307,7 +307,8 @@ def test_finalize_result_mdapi_error(job_factory, caplog):
     except MetadataParseError:
         pass
     assert job.status == job.Status.failed
-    assert job.exception == "MDAPI error\ntext"
+    assert "finalize_result" in job.exception  # includes traceback
+    assert "MDAPI error\ntext" in job.exception
 
     log_record = next(r for r in caplog.records if "errored" in r.message)
 


### PR DESCRIPTION
Also make sure that unhandled exceptions from both Jobs and Preflights store a traceback in the exception field.

As an example, before this change, we merely got an unhelpful line in the `log` field: Exception in task get_installed_packages

Now we get a full traceback and error message in the `exception` field:
<img width="816" alt="Screen Shot 2021-11-08 at 11 17 21 AM" src="https://user-images.githubusercontent.com/49014/140778424-150f85e9-6134-4285-bf08-1d3fec2622ce.png">
