### PR TITLE
Log error and context on scratch org creation failure

### DIFF
--- a/metadeploy/api/management/tests/commands.py
+++ b/metadeploy/api/management/tests/commands.py
@@ -23,7 +23,6 @@ from metadeploy.api.management.commands.schedule_release_test import (
 @pytest.mark.django_db()
 def test_run_plan(plan_factory):
     plan = plan_factory(preflight_checks=[{"when": "False", "action": "error"}])
-
     org_config = OrgConfig(
         {
             "instance_url": "https://sample.salesforce.org/",
@@ -69,6 +68,46 @@ def test_run_plan(plan_factory):
 def test_run_plan__no_plan_exists():
     with pytest.raises(CommandError):
         call_command("run_plan", "abc123")
+
+
+@pytest.mark.django_db()
+@mock.patch("metadeploy.api.management.commands.run_plan.setup_scratch_org")
+def test_run_plan__scratch_org_creation_fails(setup_scratch_org, plan_factory, caplog):
+    caplog.set_level(logging.INFO)
+    setup_scratch_org.side_effect = Exception("Scratch org creation failed")
+    plan = plan_factory(preflight_checks=[{"when": "False", "action": "error"}])
+    org_config = OrgConfig(
+        {
+            "instance_url": "https://sample.salesforce.org/",
+            "access_token": "abc123",
+            "refresh_token": "abc123",
+            "org_id": "00Dxxxxxxxxxxxxxxx",
+        },
+        "Release",
+    )
+
+    # with ExitStack() as stack:
+    # stack.enter_context(patch("metadeploy.api.jobs.local_github_checkout"))
+    # stack.enter_context(
+    # patch("metadeploy.api.salesforce.OrgConfig.refresh_oauth_token")
+    # )
+    # stack.enter_context(
+    # patch("cumulusci.core.flowrunner.PreflightFlowCoordinator.run")
+    # )
+    # stack.enter_context(patch("cumulusci.core.flowrunner.FlowCoordinator.run"))
+    # stack.enter_context(
+    # patch(
+    # "metadeploy.api.jobs.create_scratch_org_on_sf",
+    # return_value=(org_config, None, None),
+    # )
+    # )
+    # stack.enter_context(patch("metadeploy.api.jobs.delete_scratch_org_on_sf"))
+
+    with pytest.raises(Exception, match="Scratch org creation failed"):
+        call_command("run_plan", str(plan.id))
+
+    expected_output = "INFO     metadeploy.api.management.commands.run_plan:run_plan.py:37 Scratch org creation failed.\n"
+    assert caplog.text == expected_output
 
 
 @pytest.mark.django_db

--- a/metadeploy/api/management/tests/commands.py
+++ b/metadeploy/api/management/tests/commands.py
@@ -76,32 +76,6 @@ def test_run_plan__scratch_org_creation_fails(setup_scratch_org, plan_factory, c
     caplog.set_level(logging.INFO)
     setup_scratch_org.side_effect = Exception("Scratch org creation failed")
     plan = plan_factory(preflight_checks=[{"when": "False", "action": "error"}])
-    org_config = OrgConfig(
-        {
-            "instance_url": "https://sample.salesforce.org/",
-            "access_token": "abc123",
-            "refresh_token": "abc123",
-            "org_id": "00Dxxxxxxxxxxxxxxx",
-        },
-        "Release",
-    )
-
-    # with ExitStack() as stack:
-    # stack.enter_context(patch("metadeploy.api.jobs.local_github_checkout"))
-    # stack.enter_context(
-    # patch("metadeploy.api.salesforce.OrgConfig.refresh_oauth_token")
-    # )
-    # stack.enter_context(
-    # patch("cumulusci.core.flowrunner.PreflightFlowCoordinator.run")
-    # )
-    # stack.enter_context(patch("cumulusci.core.flowrunner.FlowCoordinator.run"))
-    # stack.enter_context(
-    # patch(
-    # "metadeploy.api.jobs.create_scratch_org_on_sf",
-    # return_value=(org_config, None, None),
-    # )
-    # )
-    # stack.enter_context(patch("metadeploy.api.jobs.delete_scratch_org_on_sf"))
 
     with pytest.raises(Exception, match="Scratch org creation failed"):
         call_command("run_plan", str(plan.id))


### PR DESCRIPTION
We now log an error message along with additional context if a failure during scratch org creation occurs.