### PR TITLE
set SOCIALACCOUNT_STORE_TOKENS = True 

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -414,6 +414,7 @@ SOCIALACCOUNT_PROVIDERS = {
 }
 ACCOUNT_EMAIL_VERIFICATION = "none"
 SOCIALACCOUNT_ADAPTER = "sfdo_template_helpers.oauth2.adapter.SFDOSocialAccountAdapter"
+SOCIALACCOUNT_STORE_TOKENS = True
 
 JS_REVERSE_JS_VAR_NAME = "api_urls"
 JS_REVERSE_EXCLUDE_NAMESPACES = ["admin", "admin_rest"]


### PR DESCRIPTION
(True used to be the default, but that changed in django-allauth 0.48.0)