### PR TITLE
CCI 3.55 for Flow syntax fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,3 +24,4 @@ Got feedback?
 
 Please open a new `GitHub Issue
 <https://github.com/SFDO-Tooling/MetaDeploy/issues>`_.
+

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -2,7 +2,7 @@
 
 https://github.com/SFDO-Tooling/sfdo-template-helpers/archive/v0.20.0.tar.gz
 coloredlogs
-cumulusci
+cumulusci==3.55.0.dev1
 Django<3.2
 Pillow
 ansi2html

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -94,7 +94,7 @@ cryptography==36.0.1
     #   pyopenssl
     #   service-identity
     #   sfdo-template-helpers
-cumulusci==3.54.0
+cumulusci==3.55.0.dev1
     # via -r requirements/prod.in
 daphne==3.0.2
     # via channels


### PR DESCRIPTION
CCI 3.55 has a fix for an old flow-step syntax needed by V4S.

