### PR TITLE
Allow queue overrides in cron jobs

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -470,6 +470,7 @@ CRON_JOBS = {
     "calculate_average_plan_runtimes": {
         "func": "metadeploy.api.jobs.calculate_average_plan_runtime_job",
         "cron_string": "0 0 * * *",  # run daily at midnight
+        "queue_name": "default",
     },
 }
 # There is a default dict of cron jobs,

--- a/metadeploy/management/commands/metadeploy_rqscheduler.py
+++ b/metadeploy/management/commands/metadeploy_rqscheduler.py
@@ -28,10 +28,14 @@ def register_cron_jobs(jobs: dict, queue_name: str):
         for key in ("cron_string", "func"):
             if key not in kwargs:
                 raise TypeError(f"Scheduled job {job_id} is missing {key}")
-        kwargs["queue_name"] = queue_name
+
+        # jobs can optionally specify the queue they want to be in
+        q_name = kwargs["queue_name"] if "queue_name" in kwargs else queue_name
+
+        kwargs["queue_name"] = q_name
         kwargs["use_local_timezone"] = True
         scheduler.cron(**kwargs)
-        logger.info(f"Scheduled job {job_id}: {kwargs})")
+        logger.info(f"Scheduled job {job_id}: {kwargs}")
 
 
 class Command(rqscheduler.Command):


### PR DESCRIPTION
* We now allow CRON_JOBS to specify a `queue_name`.
* Switched the `calculate_average_plan_runtime` job to run on the default queue.