### PR TITLE
Add .slugignore

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,4 @@
+/.circleci
+/.github
+docker-compose.yml
+env.example


### PR DESCRIPTION
This PR adds a .slugignore file to exclude some files from MDP's slug. [Docs]

[Docs]: https://devcenter.heroku.com/articles/slug-compiler#ignoring-files-with-slugignore
