### PR TITLE
[a11y] Corect MetaDeploy logo alt text

### DIFF
--- a/src/js/components/header/index.tsx
+++ b/src/js/components/header/index.tsx
@@ -87,8 +87,8 @@ class Header extends React.Component<Props & PropsFromRedux> {
                 <img
                   className="site-logo"
                   src={logoSrc}
-                  alt={window.SITE_NAME}
-                  title={window.SITE_NAME}
+                  alt={window.GLOBALS.SITE.company_name}
+                  title={window.GLOBALS.SITE.company_name}
                 />
               ) : null}
             </Link>


### PR DESCRIPTION
Use company name for logo alt test instead of site name

Fixes: [W-11149764](https://gus.lightning.force.com/a07EE00000x9uxkYAA)