### PR TITLE
Use company name for company logo as alt text

### DIFF
--- a/src/js/components/header/index.tsx
+++ b/src/js/components/header/index.tsx
@@ -87,8 +87,8 @@ class Header extends React.Component<Props & PropsFromRedux> {
                 <img
                   className="site-logo"
                   src={logoSrc}
-                  alt={window.SITE_NAME}
-                  title={window.SITE_NAME}
+                  alt={window.GLOBALS.SITE.company_name}
+                  title={window.GLOBALS.SITE.company_name}
                 />
               ) : null}
             </Link>

--- a/test/js/components/header/index.test.js
+++ b/test/js/components/header/index.test.js
@@ -26,6 +26,7 @@ describe('<Header />', () => {
       window.SITE_NAME = 'My Site';
       window.GLOBALS.SITE = {
         company_logo: 'my/logo.png',
+        company_name: 'My Company',
       };
     });
 
@@ -37,7 +38,7 @@ describe('<Header />', () => {
     test('renders logo', () => {
       const { getByAltText } = setup();
 
-      expect(getByAltText('My Site')).toBeVisible();
+      expect(getByAltText('My Company')).toBeVisible();
     });
   });
 


### PR DESCRIPTION
Use company name for logo alt test instead of site name

Fixes: [W-11149764](https://gus.lightning.force.com/a07EE00000x9uxkYAA)