### PR TITLE
Apply job timeout to scratch org polling

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -419,6 +419,7 @@ SOCIALACCOUNT_STORE_TOKENS = True
 JS_REVERSE_JS_VAR_NAME = "api_urls"
 JS_REVERSE_EXCLUDE_NAMESPACES = ["admin", "admin_rest"]
 
+METADEPLOY_JOB_TIMEOUT = env("METADEPLOY_JOB_TIMEOUT", type_=int, default=3600)
 
 # Redis configuration:
 
@@ -436,7 +437,7 @@ CACHES = {
 RQ_QUEUES = {
     "default": {
         "USE_REDIS_CACHE": "default",
-        "DEFAULT_TIMEOUT": env("METADEPLOY_JOB_TIMEOUT", type_=int, default=3600),
+        "DEFAULT_TIMEOUT": METADEPLOY_JOB_TIMEOUT,
         "DEFAULT_RESULT_TTL": 720,
     },
     "short": {


### PR DESCRIPTION
MetaDeploy stops polling for scratch org creation after the default job timeout length.