### PR TITLE
Don't derive `org_id` from `ScratchOrg.config`

### DIFF
--- a/metadeploy/api/views.py
+++ b/metadeploy/api/views.py
@@ -232,9 +232,8 @@ class PlanViewSet(FilterAllowedByOrgMixin, GetOneMixin, viewsets.ReadOnlyModelVi
 
         kwargs = None
         if scratch_org:
-            config = scratch_org.config
             kwargs = {
-                "org_id": config["org_id"],
+                "org_id": scratch_org.org_id,
             }
 
         if request.user.is_authenticated:


### PR DESCRIPTION
The view that handles the endpoint `POST /api/plans/<plan_id>/preflight/` was deriving the `org_id` from `ScratchOrg.config['org_id']`. This value seems to intermittently change between 15 and 18 characters. When setting `ScratchOrg.org_id` we use the `convert_to_18()` utility function to capture 18 digit values which are subsequently propagated over to any related `PreflightResults`. Therefore, we want to continue using the 18 char `org_id` values.

## Changes

Fixes a bug where re-running preflight checks for plans run against a scratch org would spin indefinitely. 