### PR TITLE
Remove newrelic-python-agent

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,11 +2,10 @@
 import os
 import sys
 
-from newrelic import agent
 
 if __name__ == "__main__":
-    agent.initialize()
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    # TODO: Remove this entire block? Seems likely to be cruft
     try:
         from django.core.management import execute_from_command_line
     except ImportError:
@@ -15,11 +14,11 @@ if __name__ == "__main__":
         # exceptions on Python 2.
         try:
             import django  # noqa: F401
-        except ImportError:
+        except ImportError as exc:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "
                 "available on your PYTHONPATH environment variable? Did you "
                 "forget to activate a virtual environment?"
-            )
+            ) from exc
         raise
     execute_from_command_line(sys.argv)

--- a/metadeploy/asgi.py
+++ b/metadeploy/asgi.py
@@ -4,7 +4,6 @@ defined in the ASGI_APPLICATION setting.
 """
 
 import os
-import sys
 
 import django
 from channels.routing import get_default_application

--- a/metadeploy/asgi.py
+++ b/metadeploy/asgi.py
@@ -8,12 +8,6 @@ import sys
 
 import django
 from channels.routing import get_default_application
-from newrelic import agent
-
-# newrelic patches sqlite in a way that interferes with coverage reporting
-if "pytest_cov" not in sys.modules:  # pragma: no cover
-    agent.initialize()
-    agent.wrap_web_transaction("django.core.handlers.base", "BaseHandler.get_response")
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 

--- a/metadeploy/rq_worker.py
+++ b/metadeploy/rq_worker.py
@@ -1,5 +1,4 @@
 from django.db import DatabaseError, InterfaceError, connections
-from rq.job import Job
 from rq.worker import HerokuWorker, Worker
 
 

--- a/metadeploy/rq_worker.py
+++ b/metadeploy/rq_worker.py
@@ -3,19 +3,6 @@ from rq.job import Job
 from rq.worker import HerokuWorker, Worker
 
 
-def wrap_job_as_background_task(Job):
-    orig = Job.perform
-
-    def wrapper(self):
-        with agent.BackgroundTask(agent.application(), self.func_name):
-            return orig(self)
-
-    Job.perform = wrapper
-
-
-wrap_job_as_background_task(Job)
-
-
 class ConnectionClosingWorkerMixin:
     """Mixin for rq workers to ensure db connections are closed."""
 

--- a/metadeploy/rq_worker.py
+++ b/metadeploy/rq_worker.py
@@ -1,5 +1,4 @@
 from django.db import DatabaseError, InterfaceError, connections
-from newrelic import agent
 from rq.job import Job
 from rq.worker import HerokuWorker, Worker
 
@@ -33,11 +32,9 @@ class ConnectionClosingWorkerMixin:
 
     def perform_job(self, *args, **kwargs):
         self.close_database()
-        agent.register_application(timeout=10.0)
         try:
             return super().perform_job(*args, **kwargs)
         finally:
-            agent.shutdown_agent(timeout=10.0)
             self.close_database()
 
     def work(self, *args, **kwargs):

--- a/metadeploy/tests/rq_worker.py
+++ b/metadeploy/tests/rq_worker.py
@@ -4,8 +4,6 @@ import pytest
 from django.db import DatabaseError, InterfaceError
 from django_rq import get_worker
 
-from metadeploy.rq_worker import wrap_job_as_background_task
-
 
 class TestConnectionClosingWorker:
     def test_close_database__good(self, mocker):

--- a/metadeploy/tests/rq_worker.py
+++ b/metadeploy/tests/rq_worker.py
@@ -7,20 +7,6 @@ from django_rq import get_worker
 from metadeploy.rq_worker import wrap_job_as_background_task
 
 
-def test_wrap_job_as_background_task(mocker):
-    mocker.patch("newrelic.agent.BackgroundTask")
-    mocker.patch("newrelic.agent.application")
-    mock_perform = MagicMock()
-
-    class Job:
-        func_name = "func"
-        perform = mock_perform
-
-    wrap_job_as_background_task(Job)
-    Job().perform()
-    mock_perform.assert_called_once()
-
-
 class TestConnectionClosingWorker:
     def test_close_database__good(self, mocker):
         conn = MagicMock()

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -30,7 +30,6 @@ djangorestframework
 github3.py
 honcho
 logfmt
-newrelic
 psycopg2-binary
 rq
 sentry-sdk

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -233,8 +233,6 @@ markupsafe==2.0.1
     #   snowfakery
 msgpack==1.0.4
     # via channels-redis
-newrelic==7.14.0.177
-    # via -r requirements/prod.in
 oauthlib==3.2.0
     # via requests-oauthlib
 packaging==21.3


### PR DESCRIPTION
Why?:

1. The last update broke the app.
2. We're not using it.

We think it's related to newrelic/newrelic-python-agent#584, but see (2) above.