### PR TITLE
Update token endpoint to enforce tenanted tokens

### DIFF
--- a/metadeploy/api/urls.py
+++ b/metadeploy/api/urls.py
@@ -5,7 +5,7 @@ from rest_framework import routers
 
 from .views import (
     JobViewSet,
-    ObtainTokenView,
+    ResetTokenView,
     OrgViewSet,
     PlanViewSet,
     ProductCategoryViewSet,
@@ -25,7 +25,7 @@ router.register("scratch-orgs", ScratchOrgViewSet, basename="scratch-org")
 urlpatterns = router.urls + [
     path("user/", UserView.as_view(), name="user"),
     path("orgs/", OrgViewSet.as_view(), name="org-list"),
-    path("token/", ObtainTokenView.as_view(), name="token"),
+    path("token/", ResetTokenView.as_view(), name="token"),
 ]
 
 if settings.API_DOCS_ENABLED:  # pragma: nocover


### PR DESCRIPTION
Rework OptainTokenView to be RefreshTokenView to not allow users to obtain tokens for a tenant they are not already authorized to. The endpoint will allow users to reset an existing token when authorized via a username and password.