### PR TITLE
Make product filtering more specific

### DIFF
--- a/metadeploy/api/github.py
+++ b/metadeploy/api/github.py
@@ -16,7 +16,8 @@ def local_github_checkout(repo_owner, repo_name, commit_ish=None):
     with temporary_dir() as repo_root:
         # pretend it's a git clone to satisfy cci
         os.mkdir(".git")
-        product = Product.objects.get(repo_url__icontains=repo_name)
+        search_string = f"/{repo_owner}/{repo_name}"
+        product = Product.objects.get(repo_url__contains=search_string)
         repo = get_github_api_for_repo(None, product.repo_url)
         if commit_ish is None:
             commit_ish = repo.repository(repo_owner, repo_name).default_branch

--- a/metadeploy/api/tests/test_github.py
+++ b/metadeploy/api/tests/test_github.py
@@ -8,12 +8,17 @@ from ..github import local_github_checkout
 
 @pytest.mark.django_db
 def test_local_github_checkout(product_factory):
-    product_factory(repo_url="https://github.com/owner/name")
+    """Ensure repos that have names which are substrings of another repo
+    name do not cause conflicts with one another."""
+    product_factory(repo_url="https://github.com/SalesforceFoundation/gem")
+    product_factory(
+        repo_url="https://github.com/SalesforceFoundation/Grants-Management"
+    )
 
     with ExitStack() as stack:
         stack.enter_context(patch("metadeploy.api.github.os"))
         stack.enter_context(patch("metadeploy.api.github.get_github_api_for_repo"))
         stack.enter_context(patch("metadeploy.api.github.download_extract_github"))
 
-        with local_github_checkout("owner", "name") as repo_root:
+        with local_github_checkout("SalesforceFoundation", "gem") as repo_root:
             assert isinstance(repo_root, str)


### PR DESCRIPTION
This fixes a bug where a product that has a repository name that is a substring of another repository name causes an error when invoking the `github_local_checkout()` method.