### PR TITLE
Expire Tenant API Tokens

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -166,6 +166,8 @@ ADMIN_API_ALLOWED_SUBNETS = [
     for net in env.list("ADMIN_API_ALLOWED_SUBNETS", default=["127.0.0.1/32"])
 ]
 
+# API Token Stuff
+API_TOKEN_EXPIRE_AFTER_DAYS = env.int("API_TOKEN_EXPIRE_AFTER_DAYS", default=30)
 
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators

--- a/docs/scheduled_jobs.md
+++ b/docs/scheduled_jobs.md
@@ -12,6 +12,7 @@ This job does four key things:
 2. Delete any OAuth tokens older than 10 minutes if the user doesn't have any running jobs currently. This can be configured with the TOKEN_LIFETIME_MINUTES environment variable.
 3. Deletes all non-staff users that have not logged in for the last thirty days.
 4. Clears the exception field in `Job` and `Preflight` records over 90 days old. (This field may contain customer metadata such as custom schema names from the org).
+5. Deletes any API tokens that are older than 30 days. The number of days can be configured with the API_TOKEN_EXPIRE_AFTER_DAYS environment variable.
 
 ## `expire_preflight_results`
 

--- a/docs/scheduled_jobs.md
+++ b/docs/scheduled_jobs.md
@@ -12,7 +12,7 @@ This job does four key things:
 2. Delete any OAuth tokens older than 10 minutes if the user doesn't have any running jobs currently. This can be configured with the TOKEN_LIFETIME_MINUTES environment variable.
 3. Deletes all non-staff users that have not logged in for the last thirty days.
 4. Clears the exception field in `Job` and `Preflight` records over 90 days old. (This field may contain customer metadata such as custom schema names from the org).
-5. Deletes any API tokens that are older than 30 days. The number of days can be configured with the API_TOKEN_EXPIRE_AFTER_DAYS environment variable.
+5. Deletes any API tokens that are older than 30 days. The number of days can be configured with the `API_TOKEN_EXPIRE_AFTER_DAYS` environment variable.
 
 ## `expire_preflight_results`
 

--- a/metadeploy/api/cleanup.py
+++ b/metadeploy/api/cleanup.py
@@ -110,7 +110,7 @@ def expire_api_access_tokens_older_than_days(days: int):
     """Delete any Admin API access tokens older than days given.
     We use @disable_site_filtering to ensure we query for tokens
     across all tenants."""
-    days_ago = timezone.now() - timedelta(days=days)
-    expired_tokens = Token.objects.filter(created__lte=days_ago)
+    obsolete_date = timezone.now() - timedelta(days=days)
+    expired_tokens = Token.objects.filter(created__lte=obsolete_date)
     if expired_tokens:
         expired_tokens.delete()

--- a/metadeploy/api/cleanup.py
+++ b/metadeploy/api/cleanup.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 
 from metadeploy.multitenancy import disable_site_filtering
 
-from .models import Job, PreflightResult, User
+from .models import Job, PreflightResult, User, Token
 from .push import user_token_expired
 
 
@@ -24,6 +24,9 @@ def cleanup_user_data():
 
     # remove job exceptions after 90 days
     clear_old_exceptions()
+
+    # expire API access tokens after specified number of days
+    expire_api_access_tokens_older_than_days(settings.API_TOKEN_EXPIRE_AFTER_DAYS)
 
 
 def expire_oauth_tokens():
@@ -100,3 +103,14 @@ def fix_dead_jobs_status():
     Job.objects.filter(status="started", enqueued_at__lte=timeout_ago).update(
         **canceled_values
     )
+
+
+@disable_site_filtering()
+def expire_api_access_tokens_older_than_days(days: int):
+    """Delete any Admin API access tokens older than days given.
+    We use @disable_site_filtering to ensure we query for tokens
+    across all tenants."""
+    days_ago = timezone.now() - timedelta(days=days)
+    expired_tokens = Token.objects.filter(created__lte=days_ago)
+    if expired_tokens:
+        expired_tokens.delete()


### PR DESCRIPTION
* API Tokens are now expired after 30 days. The number of days can be configured by setting the `API_TOKEN_EXPIRE_AFTER_DAYS` environment variable.