### PR TITLE
added an aria-label for the link surrounding a product card

### DIFF
--- a/locales_dev/en/translation.json
+++ b/locales_dev/en/translation.json
@@ -74,7 +74,6 @@
   "Pre-install validation completed successfully.": "Pre-install validation completed successfully.",
   "Pre-install validation encountered {{errorSummary}}.": "Pre-install validation encountered {{errorSummary}}.",
   "Pre-install validation has expired; please run it again.": "Pre-install validation has expired; please run it again.",
-  "Product Link": "Product Link",
   "Product Terms of Use and Licenses": "Product Terms of Use and Licenses",
   "Production or Developer Org": "Production or Developer Org",
   "Products": "Products",

--- a/locales_dev/en/translation.json
+++ b/locales_dev/en/translation.json
@@ -74,6 +74,7 @@
   "Pre-install validation completed successfully.": "Pre-install validation completed successfully.",
   "Pre-install validation encountered {{errorSummary}}.": "Pre-install validation encountered {{errorSummary}}.",
   "Pre-install validation has expired; please run it again.": "Pre-install validation has expired; please run it again.",
+  "Product Link": "Product Link",
   "Product Terms of Use and Licenses": "Product Terms of Use and Licenses",
   "Production or Developer Org": "Production or Developer Org",
   "Products": "Products",

--- a/src/js/components/products/listItem.tsx
+++ b/src/js/components/products/listItem.tsx
@@ -24,7 +24,9 @@ const ProductItem = ({ item }: { item: Product }) => {
       <Link
         to={routes.product_detail(item.slug)}
         className="slds-text-link_reset"
-        aria-label={`${item.title} ${t('Version {{version}}', { version: label })}`}
+        aria-label={`${item.title} ${t('Version {{version}}', {
+          version: label,
+        })}`}
       >
         <Card
           heading={item.title}

--- a/src/js/components/products/listItem.tsx
+++ b/src/js/components/products/listItem.tsx
@@ -24,7 +24,7 @@ const ProductItem = ({ item }: { item: Product }) => {
       <Link
         to={routes.product_detail(item.slug)}
         className="slds-text-link_reset"
-        aria-label={`${t('Product Link')}: ${item.title} version ${label}`}
+        aria-label={`${item.title} ${t('Version {{version}}', { version: label })}`}
       >
         <Card
           heading={item.title}

--- a/src/js/components/products/listItem.tsx
+++ b/src/js/components/products/listItem.tsx
@@ -24,6 +24,7 @@ const ProductItem = ({ item }: { item: Product }) => {
       <Link
         to={routes.product_detail(item.slug)}
         className="slds-text-link_reset"
+        aria-label={`${t('Product Link')}: ${item.title} version ${label}`}
       >
         <Card
           heading={item.title}


### PR DESCRIPTION
added an aria-label for the link surrounding a product card
See #W-11149827

A couple of things I'm not sure of:
* I set the aria-label on the Link component. Other choices were the outer div or the inner Card. 
* I set the label text to be "Product Link: <product name> version <version>". Is that too wordy?
* I only added a translation for "Product Link:" rather than the entire label. Is that correct or should the entire string be translated? 