### PR TITLE
Fix `_deploy_org_settings` to get the latest_api_version for deploy

### DIFF
--- a/metadeploy/api/salesforce.py
+++ b/metadeploy/api/salesforce.py
@@ -127,8 +127,17 @@ def _deploy_org_settings(*, cci, org_name, scratch_org_config, scratch_org):
         keychain=cci.keychain,
         sbx_login=True,
     )
-    path = os.path.join(cci.project_config.repo_root, scratch_org_config.config_file)
-    task_config = TaskConfig({"options": {"definition_file": path}})
+    path = os.path.join(
+        cci.project_config.repo_root, scratch_org_config.config_file
+    )
+    task_config = TaskConfig(
+        {
+            "options": {
+                "definition_file": path,
+                "api_version": org_config.latest_api_version,
+            }
+        }
+    )
     task = DeployOrgSettings(cci.project_config, task_config, org_config)
     task()
     return org_config


### PR DESCRIPTION
This pull request attempts to resolve problem caused by the fact that MetaDeploy attempts to deploy settings from the JSON file, by instantiating the OrgSettings task.
Metadeploy instantiates OrgSettings using the repo_root (and thus cumulusci.yml) of the project. It picks up the API Version of the project and tries to use that API Version to talk to the devhub. 

Since the ise-demo-solution project is pre-release and has features required on metadata api version 57.0, it tries to talk to the Devhub with an API version that the Devhub doesn't support yet.

Confusing everything is that MetaDeploy was deleting the uncreated scratch orgs and job logs, so we had to use the Heroku logs to figure out what was going on. This is a huge observability fail.