### PR TITLE
Remove link from the breadcrumb on plan pages

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,7 +2,6 @@
 import os
 import sys
 
-
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
     # TODO: Remove this entire block? Seems likely to be cruft

--- a/metadeploy/api/github.py
+++ b/metadeploy/api/github.py
@@ -8,6 +8,7 @@ import os
 
 from cumulusci.core.github import get_github_api_for_repo
 from cumulusci.utils import download_extract_github, temporary_dir
+
 from metadeploy.api.models import Product
 
 

--- a/metadeploy/api/tests/test_github.py
+++ b/metadeploy/api/tests/test_github.py
@@ -1,7 +1,7 @@
-import pytest
-
 from contextlib import ExitStack
 from unittest.mock import patch
+
+import pytest
 
 from ..github import local_github_checkout
 

--- a/metadeploy/api/tests/test_jobs.py
+++ b/metadeploy/api/tests/test_jobs.py
@@ -7,7 +7,6 @@ import pytest
 import pytz
 import vcr
 from cumulusci.salesforce_api.exceptions import MetadataParseError
-
 from django.conf import settings
 from django.utils import timezone
 from django.utils.timezone import make_aware
@@ -151,7 +150,9 @@ def test_preflight_failure(
 @pytest.mark.django_db
 def test_expire_preflights(user_factory, plan_factory, preflight_result_factory):
     now = timezone.now()
-    eleven_minutes_ago = now - timedelta(minutes=settings.PREFLIGHT_LIFETIME_MINUTES + 1)
+    eleven_minutes_ago = now - timedelta(
+        minutes=settings.PREFLIGHT_LIFETIME_MINUTES + 1
+    )
     user = user_factory()
     plan = plan_factory()
     preflight1 = preflight_result_factory(

--- a/src/js/components/plans/header.tsx
+++ b/src/js/components/plans/header.tsx
@@ -1,14 +1,11 @@
 import PageHeader from '@salesforce/design-system-react/components/page-header';
 import React, { ReactNode } from 'react';
 import { Trans } from 'react-i18next';
-import { Link } from 'react-router-dom';
 
 import ProductIcon from '@/js/components/products/icon';
 import { Job } from '@/js/store/jobs/reducer';
 import { Plan } from '@/js/store/plans/reducer';
 import { Product, Version } from '@/js/store/products/reducer';
-import { getVersionLabel } from '@/js/utils/helpers';
-import routes from '@/js/utils/routes';
 
 const Header = ({
   product,

--- a/src/js/components/plans/header.tsx
+++ b/src/js/components/plans/header.tsx
@@ -32,17 +32,9 @@ const Header = ({
       className="page-header slds-p-around_x-large"
       title={plan.title}
       trail={[
-        <Link
-          to={routes.version_detail(
-            product.slug,
-            getVersionLabel(product, version),
-          )}
-          key={product.slug}
-        >
-          <Trans i18nKey="productWithVersion">
-            {{ product: product.title }} {{ version: version.label }}
-          </Trans>
-        </Link>,
+        <Trans i18nKey="productWithVersion" key={product.slug}>
+          {{ product: product.title }} {{ version: version.label }}
+        </Trans>,
       ]}
       onRenderActions={onRenderActions ? onRenderActions : null}
       icon={<ProductIcon item={product} />}


### PR DESCRIPTION
This removes the link from the name of the product in the plan page. 

See [W-11149809](https://gus.lightning.force.com/a07EE00000xA3mBYAS)

According to an a11y audit, the contrast was too low and the link was redundant since there's a link further down the page. Turning off the link improved the contrast.