### PR TITLE
Make Plan Step log more accessible

### DIFF
--- a/src/sass/components/_steps.scss
+++ b/src/sass/components/_steps.scss
@@ -161,7 +161,7 @@ $step-ending-columns-min: $step-type-min + $step-badge-min + $step-install-min;
   .slds-is-open > .slds-accordion__content {
     @include z-index('logs');
 
-    background: $brand-dark;
+    background: $brand-dark-active;
     color: $color-text-brand-primary;
     margin-bottom: $spacing-small * -1;
     margin-left: $spacing-large * -1;


### PR DESCRIPTION
Increased contrast of background for step log. Using `$brand-dark-active` design token from SLDS.

Before:
<img width="786" alt="Screenshot 2022-12-20 at 5 00 50 PM" src="https://user-images.githubusercontent.com/4258978/208795930-658a367e-4002-4062-a06e-ce2afb47dc56.png">

After:
<img width="810" alt="Screenshot 2022-12-20 at 5 00 21 PM" src="https://user-images.githubusercontent.com/4258978/208795886-0576584f-a9bf-4ae1-b5de-8a9a2b2419b6.png">

Contrast check:
<img width="640" alt="Screenshot 2022-12-20 at 4 58 38 PM" src="https://user-images.githubusercontent.com/4258978/208795859-f27240a0-1283-4a20-b64c-8894d965ac5c.png">
