### PR TITLE
Expire API Tokens

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -159,6 +159,9 @@ ADMIN_API_ALLOWED_SUBNETS = [
 ]
 
 
+# API Token Stuff
+API_TOKEN_EXPIRE_AFTER_DAYS = env.int("API_TOKEN_EXPIRE_AFTER_DAYS", default=30)
+
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
 

--- a/docs/scheduled_jobs.md
+++ b/docs/scheduled_jobs.md
@@ -12,6 +12,7 @@ This job does four key things:
 2. Delete any OAuth tokens older than 10 minutes if the user doesn't have any running jobs currently. This can be configured with the TOKEN_LIFETIME_MINUTES environment variable.
 3. Deletes all non-staff users that have not logged in for the last thirty days.
 4. Clears the exception field in `Job` and `Preflight` records over 90 days old. (This field may contain customer metadata such as custom schema names from the org).
+5. Deletes any API tokens that are older than 30 days. The number of days can be configured with the `API_TOKEN_EXPIRE_AFTER_DAYS` environment variable.
 
 ## `expire_preflight_results`
 

--- a/metadeploy/conftest.py
+++ b/metadeploy/conftest.py
@@ -8,6 +8,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from pytest_factoryboy import register
 from rest_framework.test import APIClient
+from rest_framework.authtoken.models import Token
 from sfdo_template_helpers.crypto import fernet_encrypt
 
 from metadeploy.api.models import (
@@ -292,3 +293,11 @@ def admin_api_client(user_factory):
 @pytest.fixture
 def anon_client():
     return APIClient()
+
+
+@register
+class TokenFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Token
+
+    user = factory.SubFactory(UserFactory)


### PR DESCRIPTION
We now expire Admin API Tokens after 30 days.