### PR TITLE
Implement workaround for dropdown component. Fixes W-11149825.

### DIFF
--- a/src/js/components/header/logout.tsx
+++ b/src/js/components/header/logout.tsx
@@ -28,7 +28,8 @@ const Logout = ({
             options={[
               {
                 label: user?.username,
-                type: 'header',
+                type: 'item',
+                disabled: true,
               },
               { type: 'divider' },
               {

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -17,3 +17,11 @@
 .site-logo {
   max-height: 2.5rem;
 }
+
+[aria-labelledby="logout"] {
+  .slds-dropdown__item > a[aria-disabled=true] {
+    font-weight: 500;
+    font-size: 1rem;
+    color: $color-text-default;
+  }
+}

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -18,8 +18,8 @@
   max-height: 2.5rem;
 }
 
-[aria-labelledby="logout"] {
-  .slds-dropdown__item > a[aria-disabled=true] {
+[aria-labelledby='logout'] {
+  .slds-dropdown__item > a[aria-disabled='true'] {
     font-weight: 500;
     font-size: 1rem;
     color: $color-text-default;


### PR DESCRIPTION
The Logout menu did not read the username when selected using a screen-reader. I had to implement a workaround to modify the CSS of the disabled menu item, so it visually didn't have any changes, but would read the username for screen readers.

Before:
<img width="833" alt="Screenshot 2023-01-27 at 10 54 52 AM" src="https://user-images.githubusercontent.com/4258978/215171202-7ded5838-1070-4e83-b62f-caa81c647499.png">

After:
<img width="836" alt="Screenshot 2023-01-27 at 10 55 56 AM" src="https://user-images.githubusercontent.com/4258978/215171415-4ff9362f-de6c-4bf2-b17e-f200d062eab9.png">
