### PR TITLE
Clean up assistive text for "view org" and "install another product" links.

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -68,6 +68,7 @@
   "Master Services Agreement": "Master Services Agreement",
   "Metadata": "Metadata",
   "MetaDeploy": "MetaDeploy",
+  "New Window": "New Window",
   "Not Connected to Salesforce": "Not Connected to Salesforce",
   "Oh no! This installation encountered an error.": "Oh no! This installation encountered an error.",
   "One Time Apex": "One Time Apex",

--- a/locales_dev/en/translation.json
+++ b/locales_dev/en/translation.json
@@ -63,6 +63,7 @@
   "Log in": "Log in",
   "Master Services Agreement": "Master Services Agreement",
   "MetaDeploy": "MetaDeploy",
+  "New Window": "New Window",
   "Not Connected to Salesforce": "Not Connected to Salesforce",
   "Oh no! This installation encountered an error.": "Oh no! This installation encountered an error.",
   "Only I and Salesforce staff can view this installation job.": "Only I and Salesforce staff can view this installation job.",

--- a/src/js/components/backLink.tsx
+++ b/src/js/components/backLink.tsx
@@ -20,7 +20,8 @@ const BackLink = ({
         <p className={className}>
           <Link to={url}>
             <Icon
-              assistiveText={{ label }}
+              /* blank assistive text is OK because the arrow is decorative */
+              assistiveText=""
               category="utility"
               name={name}
               size="x-small"

--- a/src/js/components/jobs/ctaButton.tsx
+++ b/src/js/components/jobs/ctaButton.tsx
@@ -55,14 +55,15 @@ const CtaButton = ({
             rel="noreferrer noopener"
             className={btnClasses}
           >
+            {t('View Org')}
             <Icon
-              containerClassName="slds-p-right_x-small"
+              containerClassName="slds-p-left_x-small"
               category="utility"
               name="new_window"
+              assistiveText={{ label: t('New Window') }}
               size="x-small"
               inverse
             />
-            {t('View Org')}
           </a>
         );
       }


### PR DESCRIPTION
Add assistive text to 'view org' button to alert screen reader users the link opens in a new window. 
Before:
<img width="831" alt="Screenshot 2023-02-23 at 1 31 24 PM" src="https://user-images.githubusercontent.com/4258978/221035015-0c52c7e7-8f8b-4bb0-beba-ee1fab01bda2.png">
After:
<img width="848" alt="Screenshot 2023-02-23 at 1 39 15 PM" src="https://user-images.githubusercontent.com/4258978/221036351-630984ba-8561-437c-b002-c4687a1f3a93.png">

Removed redundant assistive text from 'install another product' link.
Before:
<img width="816" alt="Screenshot 2023-02-23 at 1 32 05 PM" src="https://user-images.githubusercontent.com/4258978/221035097-6890aebc-2ce4-4f01-87c8-6789c9b81e01.png">
After:
<img width="839" alt="Screenshot 2023-02-23 at 1 39 31 PM" src="https://user-images.githubusercontent.com/4258978/221036385-5e8c68b5-ea11-46fc-8901-ee2c60a3b82d.png">
