### PR TITLE
Make Contents of `django-js-reverse` available via API.

### DIFF
--- a/metadeploy/api/tests/test_views.py
+++ b/metadeploy/api/tests/test_views.py
@@ -1,5 +1,6 @@
 from contextlib import ExitStack
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -908,3 +909,19 @@ def test_front_end_info(anon_client, site_profile_factory):
 
     actual_site_keys = content["SITE"].keys()
     assert expected_site_keys == set(actual_site_keys)
+
+
+@pytest.mark.django_db
+def test_reverse_endpoint(anon_client, tmp_path):
+    encoding: str = "utf-8"
+    expected_content: str = "This content is expected."
+
+    test_file: Path = tmp_path / "test.txt"
+    test_file.write_text(expected_content, encoding=encoding)
+
+    with patch("metadeploy.api.views.BootstrapView.js_reverse_filepath", test_file):
+        url = reverse("ui-reverse")
+        response = anon_client.get(url)
+
+    assert response.status_code == 200
+    assert response.content.decode(encoding) == expected_content

--- a/metadeploy/api/views.py
+++ b/metadeploy/api/views.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from functools import reduce
 from logging import getLogger
+from pathlib import Path
 
 import django_rq
 from django.conf import settings
@@ -8,7 +9,7 @@ from django.contrib.auth import get_user_model
 from django.core import exceptions
 from django.core.cache import cache
 from django.db.models import Q
-from django.http import Http404, HttpResponseRedirect, JsonResponse
+from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import generics, mixins, status, viewsets
@@ -384,6 +385,9 @@ class ScratchOrgViewSet(viewsets.GenericViewSet):
 
 
 class BootstrapView(viewsets.GenericViewSet):
+
+    js_reverse_filepath: Path = Path("staticfiles/django_js_reverse/js/reverse.js")
+
     @action(detail=False, methods=["GET"])
     def bootstrap(self, requst):
         site_profile = SiteProfile.objects.first()
@@ -397,3 +401,10 @@ class BootstrapView(viewsets.GenericViewSet):
             "SCRATCH_ORGS_AVAILABLE": bool(settings.DEVHUB_USERNAME),
         }
         return JsonResponse(data)
+
+    @action(detail=False, methods=["GET"])
+    def reverse(self, request):
+        """Endpoint to supply the front-end with the contents
+        of js file produced by django-js-reverse"""
+        with open(self.js_reverse_filepath, "r", encoding="utf-8") as f:
+            return HttpResponse(f.read(), content_type="text/plain")


### PR DESCRIPTION
* MetaDeploy now serves the contents of `staticfiles/django_js_reverse/js/reverse.js` under the `/api/ui/reverse` endpoint.