### PR TITLE
Fix Stalled Preflights

### DIFF
--- a/metadeploy/api/jobs.py
+++ b/metadeploy/api/jobs.py
@@ -328,6 +328,11 @@ def expire_preflights():
         is_valid=True,
     )
     for preflight in preflights_to_invalidate:
+        # If the status is "Started" then we can assume this job
+        # is stalled (e.g. from a dyno restart) and needs
+        # to be set to a "canceled" status
+        if preflight.status == PreflightResult.Status.started:
+            preflight.status = PreflightResult.Status.canceled
         preflight.is_valid = False
         preflight.save()
 

--- a/metadeploy/api/tests/test_jobs.py
+++ b/metadeploy/api/tests/test_jobs.py
@@ -158,6 +158,7 @@ def test_expire_preflights(user_factory, plan_factory, preflight_result_factory)
     preflight1 = preflight_result_factory(
         user=user, plan=plan, status=PreflightResult.Status.complete, org_id=user.org_id
     )
+    # This preflight is in a "started" status, and we expect it to be changed to "cancelled"
     preflight2 = preflight_result_factory(
         user=user, plan=plan, status=PreflightResult.Status.started, org_id=user.org_id
     )
@@ -179,6 +180,7 @@ def test_expire_preflights(user_factory, plan_factory, preflight_result_factory)
 
     assert not preflight1.is_valid
     assert not preflight2.is_valid
+    assert preflight2.status == PreflightResult.Status.canceled
     assert preflight3.is_valid
     assert preflight4.is_valid
 


### PR DESCRIPTION
## Bugs Fixed
* Fixed a bug where a preflight job stuck in a `started` status due to a dyno restart would block user's from re-running preflight checks.

## Dev Notes
The manifestation of this bug in the UI was a little confusing. Both "Pre-install validation completed successfully" and "A pre-install validation is currently running on this org" were displayed in the UI at the same time. Because preflights default `is_valid=True`, the front-end picks up the `is_valid` and displays the "completed" message, while the "currently running" message is shown because of the preflight associated with the user's org is still in a "started" status. The `expire_preflights` job now looks for preflights with a status of `started` that are older than 10 minutes. If this status is detected, then it is updated to `canceled`.