### PR TITLE
Modify dropdown config for login component

### DIFF
--- a/src/js/components/header/login.tsx
+++ b/src/js/components/header/login.tsx
@@ -39,7 +39,7 @@ class Login extends Component<Props, { modalOpen: boolean }> {
     buttonVariant: 'base',
     disabled: false,
     direction: 'ltr',
-    menuPosition: 'overflowBoundaryElement',
+    menuPosition: 'absolute',
     flipped: false,
     redirectParams: {},
   };


### PR DESCRIPTION
change from 'overflowBoundaryElement' to 'absolute' for dropdown posi…tion in login button component. The fixes an a11y bug preventing mobile voiceover users from accessing the dropdown menu due to the dropdown menu being rendered in a detached render tree