### PR TITLE
Remove mock DB_ENCRYPTION_KEY

### DIFF
--- a/env.example
+++ b/env.example
@@ -26,6 +26,7 @@ DEVHUB_USERNAME=
 #BUCKETEER_AWS_SECRET_ACCESS_KEY=
 #BUCKETEER_BUCKET_NAME=
 
-# Change this to a new key,
-# generated using cryptography.fernet.Fernet.generate_key()
-DB_ENCRYPTION_KEY="Ul-OySkEawSxUc7Ck13Twu2109IzIFh54C1WXO9KAFE="
+# Change this to a new key, run the following
+# python -c "from cryptography.fernet import Fernet;print(str(Fernet.generate_key(), 'utf8'))"
+# Ul-OySkEawSxUc7Ck13Twu2109IzIFh54C1WXO9KAFE=
+DB_ENCRYPTION_KEY=


### PR DESCRIPTION
Having the mock DB_ENCRYPTION_KEY in env.example resulted in false
positives during static analysis. This commit removes the mock key, and
improves documentation by including a working one-liner to generate a
valid fernet key.
