### PR TITLE
Make Omnistudio local compiler optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "heroku-postbuild": "yarn prod"
   },
   "dependencies": {
-    "@omnistudio/omniscript-lwc-compiler": "^244.4.0",
     "@react-hook/window-scroll": "^1.3.0",
     "@salesforce-ux/design-system": "^2.18.1",
     "@salesforce/design-system-react": "^0.10.48",
@@ -153,6 +152,9 @@
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.9.3",
     "webpack-merge": "^5.8.0"
+  },
+  "optionalDependencies": {
+    "@omnistudio/omniscript-lwc-compiler": "^244.4.0"
   },
   "resolutions": {
     "@storybook/**/ansi-regex": "^5.0.1",


### PR DESCRIPTION
External users may not have access to the Vlocity private NPM
repository, blocking them from installing front end dependencies. This
change allows yarn install to complete successfully.
