### PR TITLE
Validate websocket origin

### DIFF
--- a/metadeploy/routing.py
+++ b/metadeploy/routing.py
@@ -1,5 +1,6 @@
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
 from channels.sessions import SessionMiddlewareStack
 from django.core.asgi import get_asgi_application
 from django.urls import path
@@ -20,6 +21,8 @@ websockets = URLRouter(
 application = ProtocolTypeRouter(
     {
         "http": get_asgi_application(),
-        "websocket": SessionMiddlewareStack(AuthMiddlewareStack(websockets)),
+        "websocket": AllowedHostsOriginValidator(
+            SessionMiddlewareStack(AuthMiddlewareStack(websockets))
+        ),
     }
 )


### PR DESCRIPTION
WebSockets can be initiated from any site on the internet and still have the user’s cookies and session. This pull request restricts the sites which are allowed to open sockets to the app.

See W-14666893
