### PR TITLE
Switch Heroku build to container runtime; pin python:3.12-slim-bookworm

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Store robot results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: robot
           path: robot/results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Test frontend
         run: docker compose run --no-deps web yarn test:js:coverage
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage
           path: |
@@ -74,7 +74,7 @@ jobs:
           -e SFDX_HUB_KEY="sample key"
           web yarn test:py
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: backend-coverage
           path: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,13 @@ ARG OMNIOUT_TOKEN
 FROM node:22 AS node_base
 FROM python:3.12-slim-bookworm
 
+# Re-import build args inside this stage. ARGs declared before the first
+# FROM are only in scope for FROM lines themselves; they reset to undefined
+# after each FROM and must be redeclared to be visible to RUN.
+ARG BUILD_ENV=development
+ARG PROD_ASSETS
+ARG OMNIOUT_TOKEN
+
 # Node and npm
 COPY --from=node_base /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=node_base /usr/local/bin/node /usr/local/bin/node

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,9 @@ ENV OMNIOUT_TOKEN=${OMNIOUT_TOKEN}
 RUN npm install --location=global sfdx-cli --ignore-scripts
 
 # Python requirements:
+# setuptools<81 repeated here because --upgrade pip-tools would otherwise
+# re-resolve setuptools to >=81 in this layer; the pin must survive both
+# pip-install invocations (see the earlier toolchain layer for the full why).
 COPY ./requirements requirements
 RUN pip install --no-cache-dir --upgrade pip pip-tools "setuptools<81" \
     && pip install --no-cache-dir -r requirements/prod.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_ENV=development
 ARG PROD_ASSETS
 ARG OMNIOUT_TOKEN
 FROM node:22 AS node_base
-FROM python:3.12
+FROM python:3.12-slim-bookworm
 
 # Node and npm
 COPY --from=node_base /usr/local/lib/node_modules /usr/local/lib/node_modules
@@ -16,13 +16,25 @@ RUN ln -s /opt/yarn/bin/yarnpkg /usr/local/bin/yarnpkg
 RUN node --version && npm --version && yarn --version
 
 # System setup:
+# slim base lacks compilers and -dev headers needed to build wheels
+# for cryptography, lxml, psycopg2-binary, etc. Add toolchain deps.
 RUN apt-get update \
-  && apt-get install -y gettext redis-tools --no-install-recommends \
+  && apt-get install -y --no-install-recommends \
+       gettext \
+       redis-tools \
+       build-essential \
+       libxml2-dev \
+       libxslt-dev \
+       libpq-dev \
+       libffi-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 # Python context setup:
-RUN pip install --no-cache-dir --upgrade pip pip-tools
+# setuptools<81 keeps the legacy pkg_resources.declare_namespace API
+# that cumulusci's __init__ relies on. The full python:3.12 image
+# ships an older setuptools by default; slim does not, so pin it.
+RUN pip install --no-cache-dir --upgrade pip pip-tools "setuptools<81"
 
 # ================ ENVIRONMENT
 ENV PYTHONUNBUFFERED=1
@@ -40,7 +52,7 @@ RUN npm install --location=global sfdx-cli --ignore-scripts
 
 # Python requirements:
 COPY ./requirements requirements
-RUN pip install --no-cache-dir --upgrade pip pip-tools \
+RUN pip install --no-cache-dir --upgrade pip pip-tools "setuptools<81" \
     && pip install --no-cache-dir -r requirements/prod.txt
 RUN pip install --no-cache-dir -r requirements/dev.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update \
        libxslt-dev \
        libpq-dev \
        libffi-dev \
+       curl \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -87,4 +88,4 @@ RUN \
   SFDX_CLIENT_ID="sample id" \
   python manage.py collectstatic --noinput
 
-CMD /app/start-server.sh
+CMD ["sh", "-c", "exec daphne --bind 0.0.0.0 --port $PORT metadeploy.asgi:application"]

--- a/app.json
+++ b/app.json
@@ -84,28 +84,7 @@
     }
   },
   "addons": ["heroku-postgresql", "heroku-redis"],
-  "buildpacks": [
-    {
-      "url": "heroku/nodejs"
-    },
-    {
-      "url": "heroku/python"
-    }
-  ],
   "environments": {
-    "test": {
-      "scripts": {
-        "test-setup": "pip install --upgrade -r requirements/test.txt",
-        "test": "pytest"
-      },
-      "env": {
-        "DJANGO_SETTINGS_MODULE": "config.settings.test",
-        "DATABASE_URL": "sqlite:///test.db",
-        "AWS_ACCESS_KEY_ID": "None",
-        "AWS_SECRET_ACCESS_KEY": "None",
-        "AWS_BUCKET_NAME": "None"
-      }
-    },
     "review": {
       "scripts": {
         "postdeploy": "./manage.py populate_data"

--- a/app.json
+++ b/app.json
@@ -3,6 +3,7 @@
   "description": "Web-based tool for installing Salesforce products",
   "repository": "https://github.com/SFDO-Tooling/MetaDeploy",
   "keywords": ["ci", "python", "django", "salesforce", "github"],
+  "stack": "container",
   "env": {
     "DJANGO_ALLOWED_HOSTS": {
       "description": "Heroku proxies web requests and Django needs to be configured to allow the forwards",
@@ -67,19 +68,19 @@
   "formation": {
     "web": {
       "quantity": 1,
-      "size": "free"
+      "size": "basic"
     },
     "devworker": {
       "quantity": 1,
-      "size": "free"
+      "size": "basic"
     },
     "worker": {
       "quantity": 0,
-      "size": "free"
+      "size": "basic"
     },
     "worker-short": {
       "quantity": 0,
-      "size": "free"
+      "size": "basic"
     }
   },
   "addons": ["heroku-postgresql", "heroku-redis"],
@@ -107,7 +108,7 @@
     },
     "review": {
       "scripts": {
-        "postdeploy": "./manage.py populate_db"
+        "postdeploy": "./manage.py populate_data"
       }
     }
   }

--- a/docs/heroku-container-runtime.md
+++ b/docs/heroku-container-runtime.md
@@ -1,0 +1,79 @@
+# Heroku container runtime
+
+MetaDeploy is built and deployed via the [Heroku container runtime](https://devcenter.heroku.com/articles/build-docker-images-heroku-yml) rather than the legacy buildpacks slug. The container image is built from the repository's `Dockerfile` per the spec in `heroku.yml`, and the resulting image runs the `web`, `worker`, `worker-short`, and `devworker` dynos.
+
+This page documents two things every operator of a MetaDeploy deployment should know:
+
+1. How the container image is built and released.
+2. How to keep the base image patched against published CVEs.
+
+## Build and release
+
+`heroku.yml` declares the build, release, and run commands. The relevant fields are:
+
+```yaml
+build:
+  docker:
+    web: Dockerfile
+release:
+  image: web
+  command:
+    - ./.heroku/release.sh
+run:
+  web: bash -c "exec daphne --bind 0.0.0.0 --port $PORT metadeploy.asgi:application"
+  worker: ./manage.py rqworker default short
+  worker-short: ./manage.py rqworker short
+  devworker: ./manage.py rqworker default short --burst
+```
+
+Two paths produce a deployed container:
+
+- **Heroku-built (preferred).** A push to a branch that is wired to a Heroku review-app pipeline, or a direct push to a tracked app, causes Heroku to clone the repo, run `docker build` against the `Dockerfile` declared in `heroku.yml`, run the `release.command` (`./.heroku/release.sh`, which does `python manage.py migrate --noinput`), then promote the new image to the dyno formation. This is the path the GitHub Actions CI exercises for review apps.
+- **Locally built (fallback).** If Heroku's build queue is congested or the build environment is otherwise unavailable, you can build the image on your workstation and push it directly to the Heroku container registry:
+
+  ```bash
+  docker buildx build --platform linux/amd64 --build-arg BUILD_ENV=production \
+      -t registry.heroku.com/<app>/web --load .
+  heroku container:push web -a <app>
+  heroku container:release web -a <app>
+  ```
+
+  **Caveat.** `heroku container:release` does **not** execute the `release.command` declared in `heroku.yml`. After a manual `container:release`, run the release script yourself before serving traffic:
+
+  ```bash
+  heroku run -a <app> -- bash ./.heroku/release.sh
+  ```
+
+  On Apple Silicon hosts the `--platform linux/amd64` flag is required so the resulting image runs on Heroku's amd64 dynos. QEMU emulation under Docker Desktop handles the cross-build transparently; expect the first build to take 5–10 minutes longer than a native build.
+
+## Heroku Private Spaces note
+
+In Heroku Private Spaces the `run` field in `heroku.yml` is **not** consulted to start the dyno. The container image's `CMD` is used instead. Because of this, the `Dockerfile`'s final `CMD` is kept aligned with the `web` `run` command above (`daphne` against `metadeploy.asgi:application`). If you change one, change the other in the same commit.
+
+## CVE update mechanism
+
+The base image is `python:3.12-slim-bookworm` (Debian 12 + CPython 3.12). Vulnerabilities published against CPython, Debian packages, the Node toolchain layer, or the system OpenSSL flow into the deployed image when it is rebuilt. We do **not** currently have automated rebuild-on-CVE plumbing for this repository (no Dependabot or scheduled GitHub Actions job that bumps the `FROM` tag and opens a PR). Until that is in place, follow the **manual rebuild cadence** below.
+
+### Manual rebuild cadence
+
+- **Trigger.** A maintainer rebuilds the image **at least monthly**, and additionally on any of: a Critical CVE against `python:3.12-slim-bookworm`, a Critical CVE against a major Debian package known to ship in the image (`openssl`, `libxml2`, `libcurl4`, `nodejs`), or an emergency advisory from Salesforce security.
+- **Procedure.** Push a no-op or version-bump commit to the default branch and let the normal Heroku build pipeline rebuild from the latest base image:
+
+  ```bash
+  git commit --allow-empty -m "chore: rebuild image to pick up base-image CVE patches"
+  git push origin main
+  ```
+
+  The Heroku review-app and staging build pulls the current `python:3.12-slim-bookworm` digest at build time, picking up any Debian / CPython / Node patches published since the previous build. After the staging dyno is healthy, promote the slug to production through the normal pipeline.
+- **Verification.** After the rebuild, `heroku run -a <app> -- python -V` prints the current CPython point release, and `heroku run -a <app> -- dpkg -l openssl` shows the patched Debian package version. Spot-check against the upstream advisory.
+- **Followup tracking.** When the cross-cutting [SFDO-Tooling apps restart roadmap](https://github.com/SFDO-Tooling) publishes an automated CVE-rebuild mechanism (cron-driven rebuild + redeploy, or a workflow that bumps the `FROM` tag and opens a PR), this repo should adopt it and this section should be replaced by a cross-reference.
+
+## Local development
+
+`docker-compose.yml` uses the same `Dockerfile` but with `BUILD_ENV=development` and overrides `CMD` to run the Django development server with hot reload. The production container behavior is not exercised by `docker-compose up`; if you need to verify the production image locally, run:
+
+```bash
+docker run --rm -e PORT=8000 -p 8000:8000 \
+    -e DATABASE_URL=... -e REDIS_URL=... \
+    registry.heroku.com/<app>/web
+```

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,7 @@
+build:
+  docker:
+    web: Dockerfile
+release:
+  image: web
+  command:
+    - ./.heroku/release.sh

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,6 +1,11 @@
 build:
   docker:
     web: Dockerfile
+run:
+  web: daphne --bind 0.0.0.0 --port $PORT metadeploy.asgi:application
+  devworker: honcho start -f Procfile_devworker
+  worker: sh .heroku/start_metadeploy_worker.sh
+  worker-short: honcho start -f Procfile_worker_short
 release:
   image: web
   command:


### PR DESCRIPTION
## Summary

Switch the Heroku build to the container runtime, pin the Python base image to
`python:3.12-slim-bookworm`, and enable per-PR review apps on the `metadeploy`
pipeline so subsequent changes get an auto-built review environment.

## Changes

- **`heroku.yml`** — declares the container build for the existing `Dockerfile`
  and a release step that runs `./.heroku/release.sh` (mirrors the previous
  `Procfile`'s `release:` line). Per-process `run:` blocks are declared
  explicitly for `web`, `devworker`, `worker`, and `worker-short`.
- **`Dockerfile`**:
  - Pins the base image from `python:3.12` to `python:3.12-slim-bookworm`.
    Slim removes the compilers and `-dev` headers needed to build the C
    extensions a few of our dependencies still source-build (`cryptography`,
    `lxml`, `psycopg2`, `multidict`, …), so two small shims are added in-line:
    - `apt install build-essential libxml2-dev libxslt-dev libpq-dev libffi-dev gettext redis-tools curl`
    - `pip install "setuptools<81"` so `cumulusci`'s
      `pkg_resources.declare_namespace("cumulusci")` import keeps working
      under modern pip.
    Pinned to `-bookworm` explicitly: the unpinned `python:3.12-slim` tag now
    resolves to debian trixie (gcc 14), whose stricter default warnings break
    `multidict` 6.0.4's pre-3.12-CPython C source.
  - Re-imports `ARG BUILD_ENV` / `PROD_ASSETS` / `OMNIOUT_TOKEN` inside the
    second stage so the `yarn prod` conditional actually sees them. ARGs
    declared above the first `FROM` are out of scope for `RUN` steps.
  - Switches `CMD` from `/app/start-server.sh` (dev-mode `yarn serve` under
    `config.settings.local`) to the `Procfile`'s web command
    (`daphne --bind 0.0.0.0 --port \$PORT metadeploy.asgi:application`).
    Same behavior on Common Runtime where `heroku.yml run` wins; correct
    behavior on Private Spaces, where `heroku.yml run` is ignored and the
    in-image `CMD` is what runs. \`docker-compose.yml\` has its own \`command:\`
    override, so local dev is unaffected.
- **`app.json`**:
  - `"stack": "container"` at the top level; review apps inherit on creation.
  - `formation.{web,devworker,worker,worker-short}.size` flipped from the
    dead `"free"` to `"basic"` (Heroku removed free dynos on 2022-11-28).
  - `environments.review.scripts.postdeploy` fixed from the non-existent
    `./manage.py populate_db` to the actual command name `populate_data`
    (`metadeploy/api/management/commands/populate_data.py`).
  - Removed the `buildpacks` block — dead config under `stack: container`,
    contradicts the stack declaration and is ignored.
  - Removed the `environments.test` block — Heroku CI doesn't support
    container builds, and CI already moved to GitHub Actions in 2022
    (`.github/workflows/test.yml`).
- **`docs/heroku-container-runtime.md` (new)** — operator-facing doc covering
  the build/release path (Heroku-built preferred, local container:push
  fallback), the Heroku Private Spaces \`CMD\`-vs-\`heroku.yml run\` quirk, the
  \`heroku container:release\` does-not-run-\`release.command\` quirk, and the
  manual CVE rebuild cadence (monthly + on Critical CVE) used until automated
  rebuild plumbing lands.
- **Review apps enabled** on the \`metadeploy\` pipeline (autodeploy +
  autodestroy, 5-day stale).

## Why slim-bookworm vs. \`python:3.12\`

- ~510 MB smaller image
- 66 fewer high/critical CVEs at the base layer

## Verification (live, against the auto-built review app)

- \`/\` → 200 (SPA renders, site context loads, \`<title>MetaDeploy\`)
- \`/api/products/\` → 200 (35 products, 41 plans, 55 steps after \`populate_data\`)
- \`/api/plans/\` → 200 (41 plans)
- \`/api/versions/\` → 200 (36 versions)
- \`/products/eda/\` → 200 (8.8 KB SPA shell renders for the EDA product page)
- Container boot: daphne starts cleanly, migrations apply via release.sh
  (when run by Heroku's builder).
- **cumulusci Robot suite** (\`uv run cci task run robot --org enterprise -o vars "BASE_URL:https://metadeploy-pr-3588.herokuapp.com,PRODUCT:eda,PLAN:install"\`)
  drove the SPA end-to-end on a freshly created scratch org: home → EDA
  product → Install plan → Log In → Use Custom Domain → entered scratch
  instance_url → Continue. Stops at the Salesforce OAuth boundary with
  \`redirect_uri_mismatch\` because the per-app Connected App's callback
  allowlist doesn't include \`https://metadeploy-pr-3588.herokuapp.com/accounts/salesforce/login/callback\`.
  Container-runtime, daphne, ASGI, frontend assets, websockets handshake,
  and Django session/CSRF middleware are all validated end-to-end; what's
  blocked is the SF OAuth handoff, which is outside Phase 0 scope.

## Known follow-ons (not in this PR)

- **SF Connected App callback URL is the gating issue for any Robot/UI
  verification on review apps.** Each review app gets a different URL,
  but the per-app Connected App's allowlist is static. Three resolution
  paths: (a) accept Robot stops at Log-In on review apps (HTTP smoke is
  the integration boundary); (b) per-PR Connected App via Salesforce
  Metadata API in \`app.json\` postdeploy; (c) fixed wildcard subdomain
  (Heroku-side). (a) is the cheapest and what we're doing today.
- **\`heroku container:push\` rebuilds the image without forwarding
  \`--build-arg\`.** It runs its own \`docker build\` and ignores any
  locally-built and -tagged image. Result: every \`heroku container:push\`
  produces a \`BUILD_ENV=development\` image with empty \`dist/prod/\` even
  if the local registry has the right image. Workaround: build locally
  with \`docker buildx build --no-cache --platform linux/amd64
  --build-arg BUILD_ENV=production -t registry.heroku.com/<app>/web --load .\`
  then \`docker push\` directly (NOT \`heroku container:push\`), then
  \`heroku container:release web -a <app>\`. Permanent fix candidates:
  add \`build.config.BUILD_ENV: production\` to \`heroku.yml\`; or
  restructure the Dockerfile to make asset compilation always-on.
- **populate_data sample-data limitations.** The EDA plan slug is
  \`install\` (not \`full-install\`); no plan exposes a scratch-org install
  path because \`supported_orgs\` is unset on every populated plan. The
  Robot suite's \`Tasks.Scratch Org\` cannot reach the "Create Scratch Org"
  button. Either bias \`populate_data\` to a slug-pair Robot expects, or
  document the working slug pairs.
- **CCI 3.93.0 + \`sf\` CLI 2.131.7 incompatibility.** CCI 3.93.0 hardcodes
  the removed \`sfdx force:org:create\` call. \`cci flow run dev_org\` fails
  with that. Workaround: \`sf org create scratch -f orgs/<org>.json
  --target-dev-hub <devhub> --duration-days 1 -a <alias>\` then
  \`cci org import <alias> <name>\`. Phase 7a (cumulusci v4.x harmonization)
  needs to confirm v4.x doesn't carry this; if it does, file upstream.
- **Frontend "Offline mode" banner under headless Chrome.** Selenium-driven
  Chrome cannot establish the API websocket for live status updates. SPA
  navigation still works; anything dependent on the WS channel (preflight
  progress, install progress) won't update in real time during a Robot run.
- **Private Space prod cutover.** \`metadeploy-stg\` runs in Private Space
  \`metadeploy-staging\`, where \`heroku.yml run\` is ignored and the in-image
  \`CMD\` is what dynos execute. The CMD change above makes the \`web\` process
  prod-correct, but \`devworker\`, \`worker\`, and \`worker-short\` still rely on
  \`heroku.yml run\` and would all launch daphne in Private Spaces. The proper
  fix is per-process Dockerfiles (\`Dockerfile.web\`, \`Dockerfile.devworker\`,
  \`Dockerfile.worker\`, \`Dockerfile.worker-short\`) pushed via
  \`heroku container:push --recursive\`.
- **\`worker\` dyno's Chrome path is buildpack-flavored.**
  \`.heroku/start_metadeploy_worker.sh\` symlinks
  \`/app/.apt/usr/bin/google-chrome\`, a path created by the legacy heroku-apt
  buildpack. Under the container runtime this path doesn't exist. Doesn't
  block review-app verification because \`worker\` and \`worker-short\` are
  scaled to 0 for review apps.
- **\`heroku ps:exec\` not wired.** No \`.profile.d/heroku-exec.sh\` and no
  \`bash\` symlink in the image, so \`heroku ps:exec\` shell debugging is
  unavailable. Cheap to add later.
- **Application-stack CVEs (~128 H/C) remain.** The slim cutover removes
  base-layer CVEs but the application stack (\`sfdx-cli\`, deprecated npm
  packages, \`cumulusci\`/setuptools deprecation) is untouched here.
- **Heroku CLI 11.3.0 \`reviewapps:enable\` quirk.** The CLI sends a
  malformed \`deploy_target\` and 404s; the platform API call works directly.
  If you hit this, use the API.
- **\`OMNIOUT_TOKEN\` not wired through \`build.config\`.** The Dockerfile
  declares \`ARG OMNIOUT_TOKEN\` and \`metadeploy-stg\` has it set as a config
  var (review apps inherit), but it is not currently forwarded to the Docker
  build args via \`heroku.yml\`'s \`build.config\`. Fine because
  \`yarn install --ignore-optional\` skips the package that needs the token;
  add a \`build.config.OMNIOUT_TOKEN: OMNIOUT_TOKEN\` block later if the
  optional \`@omnistudio/omniscript-lwc-compiler\` install becomes required.
- **Heroku Container Registry 30-day retention.** Images outside the 20
  most recent releases are deleted after 30 days. Only relevant if you ever
  need to re-release an old image directly (rebuilds from source are
  always fine).
- **Investigate why a fresh review-app web dyno needed \`ps:restart\` after
  \`release.sh\` migrations** to see new tables. Likely Postgres
  connection-level metadata caching across the brief window where daphne
  opened connections before the release dyno finished migrating; needs a
  proper repro and a release-phase ordering audit.