### PR TITLE
fix: Restore Heroku container pipeline on Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,24 @@ RUN apt-get update \
        libpq-dev \
        libffi-dev \
        curl \
+       gnupg \
+       ca-certificates \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Google Chrome stable for the VBT (Vlocity Build Tool) compiler invoked
+# by the worker dyno during installs of OmniStudio products. Replaces the
+# heroku/google-chrome buildpack from the buildpack-stack era. The worker
+# startup symlinks /app/.apt/usr/bin/google-chrome (the legacy path VBT
+# expects); recreate that exact path here.
+RUN curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
+       | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
+  && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
+       > /etc/apt/sources.list.d/google-chrome.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends google-chrome-stable \
+  && mkdir -p /app/.apt/usr/bin \
+  && ln -s /usr/bin/google-chrome /app/.apt/usr/bin/google-chrome \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/heroku.yml
+++ b/heroku.yml
@@ -5,9 +5,18 @@ build:
     OMNIOUT_TOKEN: $OMNIOUT_TOKEN
 run:
   web: daphne --bind 0.0.0.0 --port $PORT metadeploy.asgi:application
-  devworker: honcho start -f Procfile_devworker
-  worker: sh .heroku/start_metadeploy_worker.sh
-  worker-short: honcho start -f Procfile_worker_short
+  devworker:
+    image: web
+    command:
+      - honcho start -f Procfile_devworker
+  worker:
+    image: web
+    command:
+      - sh .heroku/start_metadeploy_worker.sh
+  worker-short:
+    image: web
+    command:
+      - honcho start -f Procfile_worker_short
 release:
   image: web
   command:

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,6 +1,8 @@
 build:
   docker:
     web: Dockerfile
+  config:
+    OMNIOUT_TOKEN: $OMNIOUT_TOKEN
 run:
   web: daphne --bind 0.0.0.0 --port $PORT metadeploy.asgi:application
   devworker: honcho start -f Procfile_devworker

--- a/src/js/components/plans/header.tsx
+++ b/src/js/components/plans/header.tsx
@@ -30,7 +30,9 @@ const Header = ({
     // Set focus to the header title on mount for proper focus order (WCAG 2.4.3)
     // This ensures screen readers land on the heading first, especially on iOS VoiceOver
     if (headerRef.current) {
-      const heading = headerRef.current.querySelector('h1, h2, [class*="heading"]');
+      const heading = headerRef.current.querySelector(
+        'h1, h2, [class*="heading"]',
+      );
       if (heading && heading instanceof HTMLElement) {
         // Set tabindex to make heading focusable, then focus it
         heading.setAttribute('tabindex', '-1');

--- a/src/js/components/products/header.tsx
+++ b/src/js/components/products/header.tsx
@@ -21,7 +21,9 @@ const Header = ({
     // Set focus to the header title on mount for proper focus order (WCAG 2.4.3)
     // This ensures screen readers land on the heading first, especially on iOS VoiceOver
     if (headerRef.current) {
-      const heading = headerRef.current.querySelector('h1, h2, [class*="heading"]');
+      const heading = headerRef.current.querySelector(
+        'h1, h2, [class*="heading"]',
+      );
       if (heading && heading instanceof HTMLElement) {
         // Set tabindex to make heading focusable, then focus it
         heading.setAttribute('tabindex', '-1');


### PR DESCRIPTION
## Summary

Restore the Heroku container pipeline after the buildpack-stack to container-stack migration broke worker startup and OMNIOUT-gated builds on stg.

- **`heroku.yml`**: Pass `OMNIOUT_TOKEN` to the Docker build (needed by `@omnistudio/*` packages from `repo.vlocity.com`). Bind `web`, `worker`, `worker-short`, and `devworker` process types to the `web` image with explicit `command:` entries so each type runs the right entry point on the container stack.
- **`Dockerfile`**: Install `google-chrome-stable` and recreate the `/app/.apt/usr/bin/google-chrome` path. Replaces the `heroku/google-chrome` buildpack from the buildpack-stack era. The VBT (Vlocity Build Tool) compiler invoked by the worker dyno during OmniStudio installs needs Chrome at that path (see `.heroku/start_metadeploy_worker.sh`).
- **`src/js/components/{plans,products}/header.tsx`**: Add trailing commas to fix lint failures on `main` HEAD.

## Why

- Worker dynos crashed with R99 because the buildpack-stack Chrome path was gone but `start_metadeploy_worker.sh` still tried to symlink to it.
- Stg builds failed on `@omnistudio/omniscript-lwc-compiler` because `OMNIOUT_TOKEN` was not in scope at build time.
- The `run:` block shorthand in `heroku.yml` does not bind non-web process types to the image on the container stack, so workers ran the web `CMD` (daphne) instead of `rqworker`.

## Validation

Released to `metadeploy-stg`. v1323 is healthy:
- `web.1`, `web.2` running daphne.
- `worker.1`-`worker.4` running `rqworker default` (logs show `module=worker msg=\"Cleaning registries for queue: default\"`).
- `worker-short.1` running honcho with `worker_short` and `worker_scheduler` (logs show `short: Job OK`).

## Test plan

- [x] Build container image locally with `--build-arg OMNIOUT_TOKEN=$OMNIOUT_TOKEN`.
- [x] Push to `registry.heroku.com/metadeploy-stg/{web,worker,worker-short,devworker}` and `heroku container:release`.
- [x] Verify all dynos reach `up` state.
- [x] Verify worker process types run their intended commands (rqworker / honcho), not the inherited web CMD.
- [ ] Reviewer to confirm prod and sfdo-se-install can take the same image after this PR lands.