### PR TITLE
Feature/improve admin ux

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -401,6 +401,7 @@ RQ_QUEUES = {
     },
 }
 RQ = {"WORKER_CLASS": "metadeploy.rq_worker.ConnectionClosingWorker"}
+RQ_SHOW_ADMIN_LINK=True
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",

--- a/metadeploy/api/admin.py
+++ b/metadeploy/api/admin.py
@@ -2,6 +2,7 @@ from allauth.socialaccount.admin import SocialTokenAdmin
 from allauth.socialaccount.models import SocialToken
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.postgres.fields import ArrayField
 from django.forms.widgets import CheckboxSelectMultiple
 from django.shortcuts import redirect
@@ -264,7 +265,7 @@ class StepAdmin(MetadeployTranslatableAdmin, PlanMixin):
 
 
 @admin.register(User)
-class UserAdmin(AdminHelpTextMixin, admin.ModelAdmin):
+class UserAdmin(AdminHelpTextMixin, BaseUserAdmin):
     help_text = _(
         "GDPR reminder: The username, name, and email are personally identifiable information. "
         "They must be used for support/debugging purposes only, and not exported from this system."
@@ -311,6 +312,25 @@ class CustomSocialTokenAdmin(SocialTokenAdmin):
 
 
 if "binary_database_files" in settings.INSTALLED_APPS:  # pragma: no cover
+    from django import forms
     from binary_database_files.models import File
 
-    admin.site.register(File)
+    class FileUploadForm(forms.ModelForm):
+        upload = forms.FileField(required=False)
+
+        class Meta:
+            model = File
+            fields = ("name",)
+
+    @admin.register(File)
+    class FileAdmin(admin.ModelAdmin):
+        form = FileUploadForm
+        list_display = ("name", "size")
+
+        def save_model(self, request, obj, form, change):
+            uploaded = request.FILES.get("upload")
+            if uploaded:
+                obj.name = obj.name or uploaded.name
+                obj.content = uploaded.read()
+                obj.size = uploaded.size
+            super().save_model(request, obj, form, change)

--- a/metadeploy/api/admin.py
+++ b/metadeploy/api/admin.py
@@ -172,7 +172,11 @@ class PlanAdmin(MetadeployTranslatableAdmin):
         "created_at",
     )
     list_select_related = ("version", "version__product")
-    search_fields = ("translations__title", "version", "version__product")
+    search_fields = (
+        "translations__title",
+        "version__label",
+        "version__product__translations__title",
+    )
     readonly_fields = ("created_at",)
 
     def product(self, obj):
@@ -251,9 +255,9 @@ class StepAdmin(MetadeployTranslatableAdmin, PlanMixin):
     list_filter = ("plan__version__product",)
     search_fields = (
         "translations__name",
-        "plan__title",
+        "plan__translations__title",
         "plan__version__label",
-        "plan__version__product",
+        "plan__version__product__translations__title",
         "step_num",
         "path",
     )
@@ -274,7 +278,7 @@ class VersionAdmin(admin.ModelAdmin):
     list_filter = ("product", "is_production", "is_listed")
     list_editable = ("is_production", "is_listed")
     list_display = ("label", "product", "is_production", "is_listed", "commit_ish")
-    search_fields = ("label", "product")
+    search_fields = ("label", "product__translations__title")
 
 
 @admin.register(ClickThroughAgreement)


### PR DESCRIPTION
The Django admin UI had some miss configuration. Improves it so that managing Metadeploy is a bit easier. Fixes the following:

- Allows setting passwords during new user creation
- allow uploading file binaries to the files list
- Shows the Redis queue status
- Fixes plan search